### PR TITLE
[contracts] Make contract interactions optional in the node

### DIFF
--- a/dagger/conf.nim
+++ b/dagger/conf.nim
@@ -154,6 +154,12 @@ type
         name: "eth-account"
       .}: EthAddress
 
+      ethDeployment* {.
+        desc: "The json file describing the contract deployment"
+        defaultValue: string.default
+        name: "eth-deployment"
+      .}: string
+
     of initNode:
       discard
 

--- a/dagger/contracts/deployment.nim
+++ b/dagger/contracts/deployment.nim
@@ -16,5 +16,11 @@ proc deployment*(file = defaultFile): Deployment =
   Deployment(json: parseFile(file))
 
 proc address*(deployment: Deployment, Contract: typedesc): ?Address =
-  let address = deployment.json["contracts"][$Contract]["address"].getStr()
-  Address.init(address)
+  if deployment.json == nil:
+    return none Address
+
+  try:
+    let address = deployment.json["contracts"][$Contract]["address"].getStr()
+    Address.init(address)
+  except KeyError:
+    none Address

--- a/dagger/dagger.nim
+++ b/dagger/dagger.nim
@@ -122,7 +122,11 @@ proc new*(T: type DaggerServer, config: DaggerConf): T =
     engine = BlockExcEngine.new(localStore, wallet, network, discovery)
     store = NetworkStore.new(engine, localStore)
     erasure = Erasure.new(store, leoEncoderProvider, leoDecoderProvider)
-    contracts = ContractInteractions.new(config.ethProvider, config.ethAccount)
+    contracts = ContractInteractions.new(
+      config.ethProvider,
+      config.ethDeployment,
+      config.ethAccount
+    )
     daggerNode = DaggerNodeRef.new(switch, store, engine, erasure, discovery, contracts)
     restServer = RestServerRef.new(
       daggerNode.initRestApi(),

--- a/dagger/node.nim
+++ b/dagger/node.nim
@@ -43,7 +43,7 @@ type
     engine*: BlockExcEngine
     erasure*: Erasure
     discovery*: Discovery
-    contracts*: ContractInteractions
+    contracts*: ?ContractInteractions
 
 proc start*(node: DaggerNodeRef) {.async.} =
   await node.switch.start()
@@ -51,8 +51,8 @@ proc start*(node: DaggerNodeRef) {.async.} =
   await node.erasure.start()
   await node.discovery.start()
 
-  if not node.contracts.isNil:
-    await node.contracts.start()
+  if contracts =? node.contracts:
+    await contracts.start()
 
   node.networkId = node.switch.peerInfo.peerId
   notice "Started dagger node", id = $node.networkId, addrs = node.switch.peerInfo.addrs
@@ -65,8 +65,8 @@ proc stop*(node: DaggerNodeRef) {.async.} =
   await node.erasure.stop()
   await node.discovery.stop()
 
-  if not node.contracts.isNil:
-    await node.contracts.stop()
+  if contracts =? node.contracts:
+    await contracts.stop()
 
 proc findPeer*(
   node: DaggerNodeRef,
@@ -244,7 +244,7 @@ proc new*(
   engine: BlockExcEngine,
   erasure: Erasure,
   discovery: Discovery,
-  contracts: ContractInteractions): T =
+  contracts: ?ContractInteractions): T =
   T(
     switch: switch,
     blockStore: store,

--- a/tests/contracts/testInteractions.nim
+++ b/tests/contracts/testInteractions.nim
@@ -1,3 +1,4 @@
+import std/os
 import ./ethertest
 import dagger/contracts
 import ./examples
@@ -7,18 +8,20 @@ ethersuite "Storage Contract Interactions":
   var contracts: ContractInteractions
 
   setup:
-    contracts = ContractInteractions.new()
+    contracts = !ContractInteractions.new()
 
   test "can be instantiated with a signer and deployment info":
     let signer = provider.getSigner()
     let deployment = deployment()
-    check ContractInteractions.new(signer, deployment) != nil
+    check ContractInteractions.new(signer, deployment).isSome
 
   test "can be instantiated with a provider url and account":
     let url = "http://localhost:8545"
     let account = Address.example
-    check ContractInteractions.new(url) != nil
-    check ContractInteractions.new(url, account) != nil
+    let deployment = "vendor" / "dagger-contracts" / "deployment-localhost.json"
+    check ContractInteractions.new(url).isSome
+    check ContractInteractions.new(url, account = account).isSome
+    check ContractInteractions.new(url, deploymentFile = deployment).isSome
 
   test "provides purchasing":
     check contracts.purchasing != nil

--- a/tests/dagger/testnode.nim
+++ b/tests/dagger/testnode.nim
@@ -36,7 +36,7 @@ suite "Test Node":
     store: NetworkStore
     node: DaggerNodeRef
     discovery: Discovery
-    contracts: ContractInteractions
+    contracts: ?ContractInteractions
 
   setup:
     file = open(path.splitFile().dir /../ "fixtures" / "test.jpg")


### PR DESCRIPTION
Adds --eth-deployment parameter to specify where the deployment json file is located.
Ensures that the node does not crash when deployment json is missing or incorrect.