### PR TITLE
Disable pull request comments by codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -20,3 +20,4 @@ coverage:
         # `informational`: https://docs.codecov.com/docs/commit-status#informational
         # `threshold`: https://docs.codecov.com/docs/commit-status#threshold
         informational: true
+comment: false


### PR DESCRIPTION
Suggested change: disable the pull request comments by codecov.

They start to clutter up my inbox, and the reports are available under the `checks` tab of the PR anyway.
