### PR TITLE
build: override CMAKE_ARGS for Windows+MSYS2 environments re: libbacktrace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,8 +96,18 @@ codex.nims:
 	ln -s codex.nimble $@
 
 # nim-libbacktrace
+LIBBACKTRACE_MAKE_FLAGS := -C vendor/nim-libbacktrace --no-print-directory BUILD_CXX_LIB=0
 libbacktrace:
-	+ $(MAKE) -C vendor/nim-libbacktrace --no-print-directory BUILD_CXX_LIB=0
+ifeq ($(detected_OS), Windows)
+# MSYS2 detection
+ifneq ($(MSYSTEM),)
+	+ $(MAKE) $(LIBBACKTRACE_MAKE_FLAGS) CMAKE_ARGS="-G'MSYS Makefiles'"
+else
+	+ $(MAKE) $(LIBBACKTRACE_MAKE_FLAGS)
+endif
+else
+	+ $(MAKE) $(LIBBACKTRACE_MAKE_FLAGS)
+endif
 
 coverage:
 	$(MAKE) NIMFLAGS="--lineDir:on --passC:-fprofile-arcs --passC:-ftest-coverage --passL:-fprofile-arcs --passL:-ftest-coverage" testAll


### PR DESCRIPTION
Otherwise `-G"MinGW Makefiles"` is [included in `CMAKE_ARGS`](https://github.com/status-im/nim-libbacktrace/blob/284b3aac05a9d96c27044c389a5d27a84d8e8f4b/Makefile#L105), which does not function correctly in MSYS2 Bash.