### PR TITLE
Multiple slots in a storage contract

### DIFF
--- a/codex/contracts/market.nim
+++ b/codex/contracts/market.nim
@@ -42,18 +42,20 @@ method getRequest(market: OnChainMarket,
   else:
     return none StorageRequest
 
-method getHost(market: OnChainMarket,
-               id: array[32, byte]): Future[?Address] {.async.} =
-  let address = await market.contract.getHost(id)
-  if address != Address.default:
-    return some address
-  else:
-    return none Address
-
 method fulfillRequest(market: OnChainMarket,
                       requestId: array[32, byte],
                       proof: seq[byte]) {.async.} =
   await market.contract.fulfillRequest(requestId, proof)
+
+method getHost(market: OnChainMarket,
+               requestId: array[32, byte],
+               slotIndex: UInt256): Future[?Address] {.async.} =
+  let slotId = slotId(requestId, slotIndex)
+  let address = await market.contract.getHost(slotId)
+  if address != Address.default:
+    return some address
+  else:
+    return none Address
 
 method fillSlot(market: OnChainMarket,
                 requestId: array[32, byte],

--- a/codex/contracts/market.nim
+++ b/codex/contracts/market.nim
@@ -42,11 +42,6 @@ method getRequest(market: OnChainMarket,
   else:
     return none StorageRequest
 
-method fulfillRequest(market: OnChainMarket,
-                      requestId: array[32, byte],
-                      proof: seq[byte]) {.async.} =
-  await market.contract.fulfillRequest(requestId, proof)
-
 method getHost(market: OnChainMarket,
                requestId: array[32, byte],
                slotIndex: UInt256): Future[?Address] {.async.} =

--- a/codex/contracts/market.nim
+++ b/codex/contracts/market.nim
@@ -55,6 +55,12 @@ method fulfillRequest(market: OnChainMarket,
                       proof: seq[byte]) {.async.} =
   await market.contract.fulfillRequest(requestId, proof)
 
+method fillSlot(market: OnChainMarket,
+                requestId: array[32, byte],
+                slotIndex: UInt256,
+                proof: seq[byte]) {.async.} =
+  await market.contract.fillSlot(requestId, slotIndex, proof)
+
 method subscribeRequests(market: OnChainMarket,
                          callback: OnRequest):
                         Future[MarketSubscription] {.async.} =

--- a/codex/contracts/market.nim
+++ b/codex/contracts/market.nim
@@ -66,6 +66,17 @@ method subscribeRequests(market: OnChainMarket,
   let subscription = await market.contract.subscribe(StorageRequested, onEvent)
   return OnChainMarketSubscription(eventSubscription: subscription)
 
+method subscribeSlotFilled*(market: OnChainMarket,
+                            requestId: array[32, byte],
+                            slotIndex: UInt256,
+                            callback: OnSlotFilled):
+                           Future[MarketSubscription] {.async.} =
+  proc onEvent(event: SlotFilled) {.upraises:[].} =
+    if event.requestId == requestId and event.slotIndex == slotIndex:
+      callback(event.requestId, event.slotIndex)
+  let subscription = await market.contract.subscribe(SlotFilled, onEvent)
+  return OnChainMarketSubscription(eventSubscription: subscription)
+
 method subscribeFulfillment(market: OnChainMarket,
                             requestId: array[32, byte],
                             callback: OnFulfillment):

--- a/codex/contracts/requests.nim
+++ b/codex/contracts/requests.nim
@@ -17,14 +17,13 @@ type
     duration*: UInt256
     proofProbability*: UInt256
     reward*: UInt256
+    slots*: uint64
   StorageContent* = object
     cid*: string
     erasure*: StorageErasure
     por*: StoragePoR
   StorageErasure* = object
     totalChunks*: uint64
-    totalNodes*: uint64
-    nodeId*: uint64
   StoragePoR* = object
     u*: seq[byte]
     publicKey*: seq[byte]
@@ -44,7 +43,8 @@ func fromTuple(_: type StorageAsk, tupl: tuple): StorageAsk =
     size: tupl[0],
     duration: tupl[1],
     proofProbability: tupl[2],
-    reward: tupl[3]
+    reward: tupl[3],
+    slots: tupl[4]
   )
 
 func fromTuple(_: type StorageContent, tupl: tuple): StorageContent =
@@ -56,9 +56,7 @@ func fromTuple(_: type StorageContent, tupl: tuple): StorageContent =
 
 func fromTuple(_: type StorageErasure, tupl: tuple): StorageErasure =
   StorageErasure(
-    totalChunks: tupl[0],
-    totalNodes: tupl[1],
-    nodeId: tupl[2]
+    totalChunks: tupl[0]
   )
 
 func fromTuple(_: type StoragePoR, tupl: tuple): StoragePoR =

--- a/codex/contracts/requests.nim
+++ b/codex/contracts/requests.nim
@@ -119,3 +119,10 @@ func decode*(decoder: var AbiDecoder, T: type StorageRequest): ?!T =
 func id*(request: StorageRequest): array[32, byte] =
   let encoding = AbiEncoder.encode((request, ))
   keccak256.digest(encoding).data
+
+func slotId*(request: StorageRequest, slot: UInt256): array[32, byte] =
+  let encoding = AbiEncoder.encode((request.id, slot))
+  keccak256.digest(encoding).data
+
+func price*(request: StorageRequest): UInt256 =
+  request.ask.slots.u256 * request.ask.duration * request.ask.reward

--- a/codex/contracts/requests.nim
+++ b/codex/contracts/requests.nim
@@ -127,5 +127,11 @@ func slotId*(requestId: array[32, byte], slot: UInt256): array[32, byte] =
 func slotId*(request: StorageRequest, slot: UInt256): array[32, byte] =
   slotId(request.id, slot)
 
+func pricePerSlot*(ask: StorageAsk): UInt256 =
+  ask.duration * ask.reward
+
+func price*(ask: StorageAsk): UInt256 =
+  ask.slots.u256 * ask.pricePerSlot
+
 func price*(request: StorageRequest): UInt256 =
-  request.ask.slots.u256 * request.ask.duration * request.ask.reward
+  request.ask.price

--- a/codex/contracts/requests.nim
+++ b/codex/contracts/requests.nim
@@ -13,11 +13,11 @@ type
     expiry*: UInt256
     nonce*: array[32, byte]
   StorageAsk* = object
-    size*: UInt256
+    slots*: uint64
+    slotSize*: UInt256
     duration*: UInt256
     proofProbability*: UInt256
     reward*: UInt256
-    slots*: uint64
   StorageContent* = object
     cid*: string
     erasure*: StorageErasure
@@ -40,11 +40,11 @@ func fromTuple(_: type StorageRequest, tupl: tuple): StorageRequest =
 
 func fromTuple(_: type StorageAsk, tupl: tuple): StorageAsk =
   StorageAsk(
-    size: tupl[0],
-    duration: tupl[1],
-    proofProbability: tupl[2],
-    reward: tupl[3],
-    slots: tupl[4]
+    slots: tupl[0],
+    slotSize: tupl[1],
+    duration: tupl[2],
+    proofProbability: tupl[3],
+    reward: tupl[4]
   )
 
 func fromTuple(_: type StorageContent, tupl: tuple): StorageContent =
@@ -135,3 +135,6 @@ func price*(ask: StorageAsk): UInt256 =
 
 func price*(request: StorageRequest): UInt256 =
   request.ask.price
+
+func size*(ask: StorageAsk): UInt256 =
+  ask.slots.u256 * ask.slotSize

--- a/codex/contracts/requests.nim
+++ b/codex/contracts/requests.nim
@@ -120,9 +120,12 @@ func id*(request: StorageRequest): array[32, byte] =
   let encoding = AbiEncoder.encode((request, ))
   keccak256.digest(encoding).data
 
-func slotId*(request: StorageRequest, slot: UInt256): array[32, byte] =
-  let encoding = AbiEncoder.encode((request.id, slot))
+func slotId*(requestId: array[32, byte], slot: UInt256): array[32, byte] =
+  let encoding = AbiEncoder.encode((requestId, slot))
   keccak256.digest(encoding).data
+
+func slotId*(request: StorageRequest, slot: UInt256): array[32, byte] =
+  slotId(request.id, slot)
 
 func price*(request: StorageRequest): UInt256 =
   request.ask.slots.u256 * request.ask.duration * request.ask.reward

--- a/codex/contracts/requests.nim
+++ b/codex/contracts/requests.nim
@@ -16,7 +16,7 @@ type
     size*: UInt256
     duration*: UInt256
     proofProbability*: UInt256
-    maxPrice*: UInt256
+    reward*: UInt256
   StorageContent* = object
     cid*: string
     erasure*: StorageErasure
@@ -44,7 +44,7 @@ func fromTuple(_: type StorageAsk, tupl: tuple): StorageAsk =
     size: tupl[0],
     duration: tupl[1],
     proofProbability: tupl[2],
-    maxPrice: tupl[3]
+    reward: tupl[3]
   )
 
 func fromTuple(_: type StorageContent, tupl: tuple): StorageContent =

--- a/codex/contracts/storage.nim
+++ b/codex/contracts/storage.nim
@@ -28,7 +28,8 @@ proc withdraw*(storage: Storage) {.contract.}
 proc balanceOf*(storage: Storage, account: Address): UInt256 {.contract, view.}
 
 proc requestStorage*(storage: Storage, request: StorageRequest) {.contract.}
-proc fulfillRequest*(storage: Storage, id: Id, proof: seq[byte]) {.contract.}
+proc fillSlot*(storage: Storage, requestId: Id, slotIndex: UInt256, proof: seq[byte]) {.contract.}
+proc payoutSlot*(storage: Storage, requestId: Id, slotIndex: UInt256) {.contract.}
 proc getRequest*(storage: Storage, id: Id): StorageRequest {.contract, view.}
 proc getHost*(storage: Storage, id: Id): Address {.contract, view.}
 

--- a/codex/contracts/storage.nim
+++ b/codex/contracts/storage.nim
@@ -13,11 +13,16 @@ type
   StorageRequested* = object of Event
     requestId*: Id
     ask*: StorageAsk
+  SlotFilled* = object of Event
+    requestId* {.indexed.}: Id
+    slotIndex* {.indexed.}: UInt256
+    slotId* {.indexed.}: Id
   RequestFulfilled* = object of Event
     requestId* {.indexed.}: Id
   ProofSubmitted* = object of Event
     id*: Id
     proof*: seq[byte]
+
 
 proc collateralAmount*(storage: Storage): UInt256 {.contract, view.}
 proc slashMisses*(storage: Storage): UInt256 {.contract, view.}

--- a/codex/market.nim
+++ b/codex/market.nim
@@ -12,6 +12,7 @@ type
   Subscription* = ref object of RootObj
   OnRequest* = proc(id: array[32, byte], ask: StorageAsk) {.gcsafe, upraises:[].}
   OnFulfillment* = proc(requestId: array[32, byte]) {.gcsafe, upraises: [].}
+  OnSlotFilled* = proc(requestId: array[32, byte], slotIndex: UInt256) {.gcsafe, upraises:[].}
 
 method getSigner*(market: Market): Future[Address] {.base, async.} =
   raiseAssert("not implemented")
@@ -35,6 +36,11 @@ method fulfillRequest*(market: Market,
                        proof: seq[byte]) {.base, async.} =
   raiseAssert("not implemented")
 
+method getHost*(market: Market,
+                requestId: array[32, byte],
+                slotIndex: UInt256): Future[?Address] {.base, async.} =
+  raiseAssert("not implemented")
+
 method fillSlot*(market: Market,
                  requestId: array[32, byte],
                  slotIndex: UInt256,
@@ -50,6 +56,13 @@ method subscribeFulfillment*(market: Market,
                              requestId: array[32, byte],
                              callback: OnFulfillment):
                             Future[Subscription] {.base, async.} =
+  raiseAssert("not implemented")
+
+method subscribeSlotFilled*(market: Market,
+                            requestId: array[32, byte],
+                            slotIndex: UInt256,
+                            callback: OnSlotFilled):
+                           Future[Subscription] {.base, async.} =
   raiseAssert("not implemented")
 
 method unsubscribe*(subscription: Subscription) {.base, async, upraises:[].} =

--- a/codex/market.nim
+++ b/codex/market.nim
@@ -27,11 +27,6 @@ method getRequest*(market: Market,
                   Future[?StorageRequest] {.base, async.} =
   raiseAssert("not implemented")
 
-method fulfillRequest*(market: Market,
-                       requestId: array[32, byte],
-                       proof: seq[byte]) {.base, async.} =
-  raiseAssert("not implemented")
-
 method getHost*(market: Market,
                 requestId: array[32, byte],
                 slotIndex: UInt256): Future[?Address] {.base, async.} =

--- a/codex/market.nim
+++ b/codex/market.nim
@@ -35,6 +35,12 @@ method fulfillRequest*(market: Market,
                        proof: seq[byte]) {.base, async.} =
   raiseAssert("not implemented")
 
+method fillSlot*(market: Market,
+                 requestId: array[32, byte],
+                 slotIndex: UInt256,
+                 proof: seq[byte]) {.base, async.} =
+  raiseAssert("not implemented")
+
 method subscribeRequests*(market: Market,
                           callback: OnRequest):
                          Future[Subscription] {.base, async.} =

--- a/codex/market.nim
+++ b/codex/market.nim
@@ -27,10 +27,6 @@ method getRequest*(market: Market,
                   Future[?StorageRequest] {.base, async.} =
   raiseAssert("not implemented")
 
-method getHost*(market: Market,
-                requestId: array[32, byte]): Future[?Address] {.base, async.} =
-  raiseAssert("not implemented")
-
 method fulfillRequest*(market: Market,
                        requestId: array[32, byte],
                        proof: seq[byte]) {.base, async.} =

--- a/codex/node.nim
+++ b/codex/node.nim
@@ -339,8 +339,8 @@ proc start*(node: CodexNodeRef) {.async.} =
     contracts.sales.onClear = proc(availability: Availability, request: StorageRequest) =
       # TODO: remove data from local storage
       discard
-
-    contracts.sales.onProve = proc(cid: string): Future[seq[byte]] {.async.} =
+    contracts.sales.onProve = proc(request: StorageRequest,
+                                   slot: UInt256): Future[seq[byte]] {.async.} =
       # TODO: generate proof
       return @[42'u8]
 

--- a/codex/node.nim
+++ b/codex/node.nim
@@ -268,8 +268,6 @@ proc requestStorage*(self: CodexNodeRef,
       cid: $encodedBlk.cid,
       erasure: StorageErasure(
         totalChunks: encoded.len.uint64,
-        totalNodes: 1,  # TODO: store on multiple nodes
-        nodeId: 0       # TODO: store on multiple nodes
       ),
       por: StoragePor(
         u: @[],         # TODO: PoR setup

--- a/codex/node.nim
+++ b/codex/node.nim
@@ -313,11 +313,13 @@ proc start*(node: CodexNodeRef) {.async.} =
 
   if contracts =? node.contracts:
     # TODO: remove Sales callbacks, pass BlockStore and StorageProofs instead
-    contracts.sales.onStore = proc(cid: string, _: Availability) {.async.} =
+    contracts.sales.onStore = proc(request: StorageRequest,
+                                   slot: UInt256,
+                                   availability: Availability) {.async.} =
       ## store data in local storage
       ##
 
-      without cid =? Cid.init(cid):
+      without cid =? Cid.init(request.content.cid):
         trace "Unable to parse Cid", cid
         raise newException(CodexError, "Unable to parse Cid")
 

--- a/codex/node.nim
+++ b/codex/node.nim
@@ -220,7 +220,7 @@ proc requestStorage*(self: CodexNodeRef,
                      duration: UInt256,
                      nodes: uint,
                      tolerance: uint,
-                     maxPrice: UInt256,
+                     reward: UInt256,
                      expiry = UInt256.none): Future[?!array[32, byte]] {.async.} =
   ## Initiate a request for storage sequence, this might
   ## be a multistep procedure.
@@ -231,7 +231,7 @@ proc requestStorage*(self: CodexNodeRef,
   ## - Run the PoR setup on the erasure dataset
   ## - Call into the marketplace and purchasing contracts
   ##
-  trace "Received a request for storage!", cid, duration, nodes, tolerance, maxPrice
+  trace "Received a request for storage!", cid, duration, nodes, tolerance, reward
 
   without contracts =? self.contracts:
     trace "Purchasing not available"
@@ -262,7 +262,7 @@ proc requestStorage*(self: CodexNodeRef,
     ask: StorageAsk(
       size: encoded.size.u256,
       duration: duration,
-      maxPrice: maxPrice
+      reward: reward
     ),
     content: StorageContent(
       cid: $encodedBlk.cid,

--- a/codex/node.nim
+++ b/codex/node.nim
@@ -260,7 +260,8 @@ proc requestStorage*(self: CodexNodeRef,
 
   let request = StorageRequest(
     ask: StorageAsk(
-      size: encoded.size.u256,
+      slots: nodes + tolerance,
+      slotSize: (encoded.blockSize * encoded.steps).u256,
       duration: duration,
       reward: reward
     ),

--- a/codex/purchasing.nim
+++ b/codex/purchasing.nim
@@ -21,7 +21,6 @@ type
     market: Market
     clock: Clock
     request*: StorageRequest
-    selected*: ?Address
   PurchaseTimeout* = Timeout
 
 const DefaultProofProbability = 100.u256
@@ -77,11 +76,8 @@ proc run(purchase: Purchase) {.async.} =
       done.complete()
     let request = purchase.request
     let subscription = await market.subscribeFulfillment(request.id, callback)
-    try:
-      await done
-      purchase.selected = await market.getHost(request.id)
-    finally:
-      await subscription.unsubscribe()
+    await done
+    await subscription.unsubscribe()
 
   proc withTimeout(future: Future[void]) {.async.} =
     let expiry = purchase.request.expiry.truncate(int64)

--- a/codex/rest/api.nim
+++ b/codex/rest/api.nim
@@ -194,10 +194,6 @@ proc initRestApi*(node: CodexNodeRef, conf: CodexConf): RestRouter =
       ## duration       - the duration of the contract
       ## reward       - the maximum price the client is willing to pay
 
-      # TODO: store on multiple nodes
-      let nodes: uint = 1
-      let tolerance: uint = 0
-
       without cid =? cid.tryGet.catch, error:
         return RestApiResponse.error(Http400, error.msg)
 
@@ -205,6 +201,9 @@ proc initRestApi*(node: CodexNodeRef, conf: CodexConf): RestRouter =
 
       without params =? StorageRequestParams.fromJson(body), error:
         return RestApiResponse.error(Http400, error.msg)
+
+      let nodes = params.nodes |? 1
+      let tolerance = params.nodes |? 0
 
       without purchaseId =? await node.requestStorage(cid,
                                                       params.duration,

--- a/codex/rest/api.nim
+++ b/codex/rest/api.nim
@@ -192,7 +192,7 @@ proc initRestApi*(node: CodexNodeRef, conf: CodexConf): RestRouter =
       ##
       ## cid            - the cid of a previously uploaded dataset
       ## duration       - the duration of the contract
-      ## maxPrice       - the maximum price the client is willing to pay
+      ## reward       - the maximum price the client is willing to pay
 
       # TODO: store on multiple nodes
       let nodes: uint = 1
@@ -210,7 +210,7 @@ proc initRestApi*(node: CodexNodeRef, conf: CodexConf): RestRouter =
                                                       params.duration,
                                                       nodes,
                                                       tolerance,
-                                                      params.maxPrice,
+                                                      params.reward,
                                                       params.expiry), error:
         return RestApiResponse.error(Http500, error.msg)
 

--- a/codex/rest/json.nim
+++ b/codex/rest/json.nim
@@ -44,5 +44,4 @@ func `%`*(purchase: Purchase): JsonNode =
     "finished": purchase.finished,
     "error": purchase.error.?msg,
     "request": purchase.request,
-    "selected": purchase.selected
   }

--- a/codex/rest/json.nim
+++ b/codex/rest/json.nim
@@ -10,6 +10,8 @@ type
     duration*: UInt256
     reward*: UInt256
     expiry*: ?UInt256
+    nodes*: ?uint
+    tolerance*: ?uint
 
 proc fromJson*(_: type Availability, bytes: seq[byte]): ?!Availability =
   let json = ?catch parseJson(string.fromBytes(bytes))
@@ -24,10 +26,14 @@ proc fromJson*(_: type StorageRequestParams,
   let duration = ?catch UInt256.fromHex(json["duration"].getStr)
   let reward = ?catch UInt256.fromHex(json["reward"].getStr)
   let expiry = UInt256.fromHex(json["expiry"].getStr).catch.option
+  let nodes = strutils.fromHex[uint](json["nodes"].getStr).catch.option
+  let tolerance = strutils.fromHex[uint](json["tolerance"].getStr).catch.option
   success StorageRequestParams(
     duration: duration,
     reward: reward,
-    expiry: expiry
+    expiry: expiry,
+    nodes: nodes,
+    tolerance: tolerance
   )
 
 func `%`*(address: Address): JsonNode =

--- a/codex/rest/json.nim
+++ b/codex/rest/json.nim
@@ -8,7 +8,7 @@ import ../purchasing
 type
   StorageRequestParams* = object
     duration*: UInt256
-    maxPrice*: UInt256
+    reward*: UInt256
     expiry*: ?UInt256
 
 proc fromJson*(_: type Availability, bytes: seq[byte]): ?!Availability =
@@ -22,11 +22,11 @@ proc fromJson*(_: type StorageRequestParams,
                bytes: seq[byte]): ?! StorageRequestParams =
   let json = ?catch parseJson(string.fromBytes(bytes))
   let duration = ?catch UInt256.fromHex(json["duration"].getStr)
-  let maxPrice = ?catch UInt256.fromHex(json["maxPrice"].getStr)
+  let reward = ?catch UInt256.fromHex(json["reward"].getStr)
   let expiry = UInt256.fromHex(json["expiry"].getStr).catch.option
   success StorageRequestParams(
     duration: duration,
-    maxPrice: maxPrice,
+    reward: reward,
     expiry: expiry
   )
 

--- a/codex/sales.nim
+++ b/codex/sales.nim
@@ -95,7 +95,7 @@ func remove*(sales: Sales, availability: Availability) =
 
 func findAvailability(sales: Sales, ask: StorageAsk): ?Availability =
   for availability in sales.available:
-    if ask.size <= availability.size and
+    if ask.slotSize <= availability.size and
        ask.duration <= availability.duration and
        ask.pricePerSlot >= availability.minPrice:
       return some availability

--- a/codex/sales.nim
+++ b/codex/sales.nim
@@ -93,7 +93,7 @@ func findAvailability(sales: Sales, ask: StorageAsk): ?Availability =
   for availability in sales.available:
     if ask.size <= availability.size and
        ask.duration <= availability.duration and
-       ask.maxPrice >= availability.minPrice:
+       ask.reward >= availability.minPrice:
       return some availability
 
 proc finish(agent: SalesAgent, success: bool) =

--- a/codex/sales.nim
+++ b/codex/sales.nim
@@ -97,7 +97,7 @@ func findAvailability(sales: Sales, ask: StorageAsk): ?Availability =
   for availability in sales.available:
     if ask.size <= availability.size and
        ask.duration <= availability.duration and
-       ask.reward >= availability.minPrice:
+       ask.pricePerSlot >= availability.minPrice:
       return some availability
 
 proc finish(agent: SalesAgent, success: bool) =

--- a/codex/sales.nim
+++ b/codex/sales.nim
@@ -57,7 +57,8 @@ type
   OnStore = proc(request: StorageRequest,
                  slot: UInt256,
                  availability: Availability): Future[void] {.gcsafe, upraises: [].}
-  OnProve = proc(cid: string): Future[seq[byte]] {.gcsafe, upraises: [].}
+  OnProve = proc(request: StorageRequest,
+                 slot: UInt256): Future[seq[byte]] {.gcsafe, upraises: [].}
   OnClear = proc(availability: Availability, request: StorageRequest) {.gcsafe, upraises: [].}
   OnSale = proc(availability: Availability,
                 request: StorageRequest,
@@ -187,7 +188,7 @@ proc start(agent: SalesAgent) {.async.} =
     agent.waiting = some agent.waitForExpiry()
 
     await onStore(request, slotIndex, availability)
-    let proof = await onProve(request.content.cid)
+    let proof = await onProve(request, slotIndex)
     await market.fillSlot(request.id, slotIndex, proof)
   except CancelledError:
     raise

--- a/codex/sales.nim
+++ b/codex/sales.nim
@@ -54,7 +54,9 @@ type
     running: ?Future[void]
     waiting: ?Future[void]
     finished: bool
-  OnStore = proc(cid: string, availability: Availability): Future[void] {.gcsafe, upraises: [].}
+  OnStore = proc(request: StorageRequest,
+                 slot: UInt256,
+                 availability: Availability): Future[void] {.gcsafe, upraises: [].}
   OnProve = proc(cid: string): Future[seq[byte]] {.gcsafe, upraises: [].}
   OnClear = proc(availability: Availability, request: StorageRequest) {.gcsafe, upraises: [].}
   OnSale = proc(availability: Availability,
@@ -184,7 +186,7 @@ proc start(agent: SalesAgent) {.async.} =
 
     agent.waiting = some agent.waitForExpiry()
 
-    await onStore(request.content.cid, availability)
+    await onStore(request, slotIndex, availability)
     let proof = await onProve(request.content.cid)
     await market.fillSlot(request.id, slotIndex, proof)
   except CancelledError:

--- a/tests/codex/helpers/mockmarket.nim
+++ b/tests/codex/helpers/mockmarket.nim
@@ -58,22 +58,6 @@ method getRequest(market: MockMarket,
       return some request
   return none StorageRequest
 
-proc fulfillRequest*(market: MockMarket,
-                     requestId: array[32, byte],
-                     proof: seq[byte],
-                     host: Address) =
-  let fulfillment = Fulfillment(requestId: requestId, proof: proof, host: host)
-  market.fulfilled.add(fulfillment)
-  var subscriptions = market.subscriptions.onFulfillment
-  for subscription in subscriptions:
-    if subscription.requestId == requestId:
-      subscription.callback(requestId)
-
-method fulfillRequest*(market: MockMarket,
-                       requestId: array[32, byte],
-                       proof: seq[byte]) {.async.} =
-  market.fulfillRequest(requestid, proof, market.signer)
-
 method getHost(market: MockMarket,
                requestId: array[32, byte],
                slotIndex: UInt256): Future[?Address] {.async.} =

--- a/tests/codex/helpers/mockmarket.nim
+++ b/tests/codex/helpers/mockmarket.nim
@@ -89,6 +89,21 @@ method getHost(market: MockMarket,
       return some slot.host
   return none Address
 
+proc emitSlotFilled*(market: MockMarket,
+                     requestId: array[32, byte],
+                     slotIndex: UInt256) =
+  var subscriptions = market.subscriptions.onSlotFilled
+  for subscription in subscriptions:
+    if subscription.requestId == requestId and
+       subscription.slotIndex == slotIndex:
+      subscription.callback(requestId, slotIndex)
+
+proc emitRequestFulfilled*(market: MockMarket, requestId: array[32, byte]) =
+  var subscriptions = market.subscriptions.onFulfillment
+  for subscription in subscriptions:
+    if subscription.requestId == requestId:
+      subscription.callback(requestId)
+
 proc fillSlot*(market: MockMarket,
                requestId: array[32, byte],
                slotIndex: UInt256,
@@ -101,11 +116,7 @@ proc fillSlot*(market: MockMarket,
     host: host
   )
   market.filled.add(slot)
-  var subscriptions = market.subscriptions.onSlotFilled
-  for subscription in subscriptions:
-    if subscription.requestId == requestId and
-       subscription.slotIndex == slotIndex:
-      subscription.callback(requestId, slotIndex)
+  market.emitSlotFilled(requestId, slotIndex)
 
 method fillSlot*(market: MockMarket,
                  requestId: array[32, byte],

--- a/tests/codex/helpers/mockmarket.nim
+++ b/tests/codex/helpers/mockmarket.nim
@@ -58,13 +58,6 @@ method getRequest(market: MockMarket,
       return some request
   return none StorageRequest
 
-method getHost(market: MockMarket,
-               id: array[32, byte]): Future[?Address] {.async.} =
-  for fulfillment in market.fulfilled:
-    if fulfillment.requestId == id:
-      return some fulfillment.host
-  return none Address
-
 proc fulfillRequest*(market: MockMarket,
                      requestId: array[32, byte],
                      proof: seq[byte],

--- a/tests/codex/testpurchasing.nim
+++ b/tests/codex/testpurchasing.nim
@@ -20,16 +20,19 @@ suite "Purchasing":
     purchasing = Purchasing.new(market, clock)
     request = StorageRequest(
       ask: StorageAsk(
+        slots: uint8.example.uint64,
+        slotSize: uint32.example.u256,
         duration: uint16.example.u256,
-        size: uint32.example.u256,
+        reward: uint8.example.u256
       )
     )
 
   test "submits a storage request when asked":
     discard purchasing.purchase(request)
     let submitted = market.requested[0]
+    check submitted.ask.slots == request.ask.slots
+    check submitted.ask.slotSize == request.ask.slotSize
     check submitted.ask.duration == request.ask.duration
-    check submitted.ask.size == request.ask.size
     check submitted.ask.reward == request.ask.reward
 
   test "remembers purchases":

--- a/tests/codex/testpurchasing.nim
+++ b/tests/codex/testpurchasing.nim
@@ -30,7 +30,7 @@ suite "Purchasing":
     let submitted = market.requested[0]
     check submitted.ask.duration == request.ask.duration
     check submitted.ask.size == request.ask.size
-    check submitted.ask.maxPrice == request.ask.maxPrice
+    check submitted.ask.reward == request.ask.reward
 
   test "remembers purchases":
     let purchase1 = purchasing.purchase(request)

--- a/tests/codex/testpurchasing.nim
+++ b/tests/codex/testpurchasing.nim
@@ -74,8 +74,7 @@ suite "Purchasing":
   test "succeeds when request is fulfilled":
     let purchase = purchasing.purchase(request)
     let request = market.requested[0]
-    let proof = seq[byte].example
-    await market.fulfillRequest(request.id, proof)
+    market.emitRequestFulfilled(request.id)
     await purchase.wait()
     check purchase.error.isNone
 

--- a/tests/codex/testsales.nim
+++ b/tests/codex/testsales.nim
@@ -16,7 +16,7 @@ suite "Sales":
     ask: StorageAsk(
       duration: 60.u256,
       size: 100.u256,
-      maxPrice:42.u256
+      reward:42.u256
     ),
     content: StorageContent(
       cid: "some cid"

--- a/tests/codex/testsales.nim
+++ b/tests/codex/testsales.nim
@@ -10,13 +10,13 @@ suite "Sales":
   let availability = Availability.init(
     size=100.u256,
     duration=60.u256,
-    minPrice=42.u256
+    minPrice=600.u256
   )
   var request = StorageRequest(
     ask: StorageAsk(
       duration: 60.u256,
       size: 100.u256,
-      reward:42.u256,
+      reward: 10.u256,
       slots: 4
     ),
     content: StorageContent(
@@ -75,6 +75,13 @@ suite "Sales":
     var tooBig = request
     tooBig.ask.size = request.ask.size + 1
     discard await market.requestStorage(tooBig)
+    check sales.available == @[availability]
+
+  test "ignores request when reward is too low":
+    sales.add(availability)
+    var tooCheap = request
+    tooCheap.ask.reward = request.ask.reward - 1
+    discard await market.requestStorage(tooCheap)
     check sales.available == @[availability]
 
   test "retrieves and stores data locally":

--- a/tests/codex/testsales.nim
+++ b/tests/codex/testsales.nim
@@ -14,10 +14,10 @@ suite "Sales":
   )
   var request = StorageRequest(
     ask: StorageAsk(
+      slots: 4,
+      slotSize: 100.u256,
       duration: 60.u256,
-      size: 100.u256,
       reward: 10.u256,
-      slots: 4
     ),
     content: StorageContent(
       cid: "some cid"
@@ -73,7 +73,7 @@ suite "Sales":
   test "ignores request when no matching storage is available":
     sales.add(availability)
     var tooBig = request
-    tooBig.ask.size = request.ask.size + 1
+    tooBig.ask.slotSize = request.ask.slotSize + 1
     discard await market.requestStorage(tooBig)
     check sales.available == @[availability]
 

--- a/tests/contracts/examples.nim
+++ b/tests/contracts/examples.nim
@@ -13,11 +13,11 @@ proc example*(_: type StorageRequest): StorageRequest =
   StorageRequest(
     client: Address.example,
     ask: StorageAsk(
-      size: (1 * 1024 * 1024 * 1024).u256, # 1 Gigabyte
+      slots: 4,
+      slotSize: (1 * 1024 * 1024 * 1024).u256, # 1 Gigabyte
       duration: (10 * 60 * 60).u256, # 10 hours
       proofProbability: 4.u256, # require a proof roughly once every 4 periods
-      reward: 84.u256,
-      slots: 4
+      reward: 84.u256
     ),
     content: StorageContent(
       cid: "zb2rhheVmk3bLks5MgzTqyznLu1zqGH5jrfTA1eAZXrjx7Vob",

--- a/tests/contracts/examples.nim
+++ b/tests/contracts/examples.nim
@@ -17,7 +17,7 @@ proc example*(_: type StorageRequest): StorageRequest =
       duration: (10 * 60 * 60).u256, # 10 hours
       proofProbability: 4.u256, # require a proof roughly once every 4 periods
       reward: 84.u256,
-      slots: 42
+      slots: 4
     ),
     content: StorageContent(
       cid: "zb2rhheVmk3bLks5MgzTqyznLu1zqGH5jrfTA1eAZXrjx7Vob",

--- a/tests/contracts/examples.nim
+++ b/tests/contracts/examples.nim
@@ -16,7 +16,7 @@ proc example*(_: type StorageRequest): StorageRequest =
       size: (1 * 1024 * 1024 * 1024).u256, # 1 Gigabyte
       duration: (10 * 60 * 60).u256, # 10 hours
       proofProbability: 4.u256, # require a proof roughly once every 4 periods
-      maxPrice: 84.u256
+      reward: 84.u256
     ),
     content: StorageContent(
       cid: "zb2rhheVmk3bLks5MgzTqyznLu1zqGH5jrfTA1eAZXrjx7Vob",

--- a/tests/contracts/examples.nim
+++ b/tests/contracts/examples.nim
@@ -16,14 +16,13 @@ proc example*(_: type StorageRequest): StorageRequest =
       size: (1 * 1024 * 1024 * 1024).u256, # 1 Gigabyte
       duration: (10 * 60 * 60).u256, # 10 hours
       proofProbability: 4.u256, # require a proof roughly once every 4 periods
-      reward: 84.u256
+      reward: 84.u256,
+      slots: 42
     ),
     content: StorageContent(
       cid: "zb2rhheVmk3bLks5MgzTqyznLu1zqGH5jrfTA1eAZXrjx7Vob",
       erasure: StorageErasure(
         totalChunks: 12,
-        totalNodes: 4,
-        nodeId: 3
       ),
       por: StoragePor(
         u: @(array[480, byte].example),

--- a/tests/contracts/testContracts.nim
+++ b/tests/contracts/testContracts.nim
@@ -41,7 +41,7 @@ ethersuite "Storage contracts":
     request.client = await client.getAddress()
 
     switchAccount(client)
-    await token.approve(storage.address, request.ask.maxPrice)
+    await token.approve(storage.address, request.ask.reward)
     await storage.requestStorage(request)
     switchAccount(host)
     await token.approve(storage.address, collateralAmount)

--- a/tests/contracts/testMarket.nim
+++ b/tests/contracts/testMarket.nim
@@ -12,12 +12,13 @@ ethersuite "On-Chain Market":
   var storage: Storage
   var token: TestToken
   var request: StorageRequest
+  var slotIndex: UInt256
 
   setup:
     let deployment = deployment()
     storage = Storage.new(!deployment.address(Storage), provider.getSigner())
     token = TestToken.new(!deployment.address(TestToken), provider.getSigner())
-    await token.mint(accounts[0], 1000.u256)
+    await token.mint(accounts[0], 1_000_000_000.u256)
 
     let collateral = await storage.collateralAmount()
     await token.approve(storage.address, collateral)
@@ -28,6 +29,8 @@ ethersuite "On-Chain Market":
     request = StorageRequest.example
     request.client = accounts[0]
 
+    slotIndex = (request.ask.slots div 2).u256
+
   test "fails to instantiate when contract does not have a signer":
     let storageWithoutSigner = storage.connect(provider)
     expect AssertionError:
@@ -37,19 +40,19 @@ ethersuite "On-Chain Market":
     check (await market.getSigner()) == (await provider.getSigner().getAddress())
 
   test "supports storage requests":
-    await token.approve(storage.address, request.ask.reward)
+    await token.approve(storage.address, request.price)
     check (await market.requestStorage(request)) == request
 
   test "sets client address when submitting storage request":
     var requestWithoutClient = request
     requestWithoutClient.client = Address.default
-    await token.approve(storage.address, request.ask.reward)
+    await token.approve(storage.address, request.price)
     let submitted = await market.requestStorage(requestWithoutClient)
     check submitted.client == accounts[0]
 
   test "can retrieve previously submitted requests":
     check (await market.getRequest(request.id)) == none StorageRequest
-    await token.approve(storage.address, request.ask.reward)
+    await token.approve(storage.address, request.price)
     discard await market.requestStorage(request)
     check (await market.getRequest(request.id)) == some request
 
@@ -60,42 +63,43 @@ ethersuite "On-Chain Market":
       receivedIds.add(id)
       receivedAsks.add(ask)
     let subscription = await market.subscribeRequests(onRequest)
-    await token.approve(storage.address, request.ask.reward)
+    await token.approve(storage.address, request.price)
     discard await market.requestStorage(request)
     check receivedIds == @[request.id]
     check receivedAsks == @[request.ask]
     await subscription.unsubscribe()
 
-  test "supports fulfilling of requests":
-    await token.approve(storage.address, request.ask.reward)
+  test "supports filling of slots":
+    await token.approve(storage.address, request.price)
     discard await market.requestStorage(request)
-    await market.fulfillRequest(request.id, proof)
+    await market.fillSlot(request.id, slotIndex, proof)
 
-  test "can retrieve host that fulfilled request":
-    await token.approve(storage.address, request.ask.reward)
+  test "can retrieve host that filled slot":
+    await token.approve(storage.address, request.price)
     discard await market.requestStorage(request)
-    check (await market.getHost(request.id)) == none Address
-    await market.fulfillRequest(request.id, proof)
-    check (await market.getHost(request.id)) == some accounts[0]
+    check (await market.getHost(request.slotId(slotIndex))) == none Address
+    await market.fillSlot(request.id, slotIndex, proof)
+    check (await market.getHost(request.slotId(slotIndex))) == some accounts[0]
 
   test "support fulfillment subscriptions":
-    await token.approve(storage.address, request.ask.reward)
+    await token.approve(storage.address, request.price)
     discard await market.requestStorage(request)
     var receivedIds: seq[array[32, byte]]
     proc onFulfillment(id: array[32, byte]) =
       receivedIds.add(id)
     let subscription = await market.subscribeFulfillment(request.id, onFulfillment)
-    await market.fulfillRequest(request.id, proof)
+    for slotIndex in 0..<request.ask.slots:
+      await market.fillSlot(request.id, slotIndex.u256, proof)
     check receivedIds == @[request.id]
     await subscription.unsubscribe()
 
-  test "subscribes only to fulfillmentof a certain request":
+  test "subscribes only to fulfillment of a certain request":
     var otherRequest = StorageRequest.example
     otherRequest.client = accounts[0]
 
-    await token.approve(storage.address, request.ask.reward)
+    await token.approve(storage.address, request.price)
     discard await market.requestStorage(request)
-    await token.approve(storage.address, otherrequest.ask.reward)
+    await token.approve(storage.address, otherrequest.price)
     discard await market.requestStorage(otherRequest)
 
     var receivedIds: seq[array[32, byte]]
@@ -104,8 +108,10 @@ ethersuite "On-Chain Market":
 
     let subscription = await market.subscribeFulfillment(request.id, onFulfillment)
 
-    await market.fulfillRequest(request.id, proof)
-    await market.fulfillRequest(otherRequest.id, proof)
+    for slotIndex in 0..<request.ask.slots:
+      await market.fillSlot(request.id, slotIndex.u256, proof)
+    for slotIndex in 0..<otherRequest.ask.slots:
+      await market.fillSlot(otherRequest.id, slotIndex.u256, proof)
 
     check receivedIds == @[request.id]
 

--- a/tests/contracts/testMarket.nim
+++ b/tests/contracts/testMarket.nim
@@ -37,19 +37,19 @@ ethersuite "On-Chain Market":
     check (await market.getSigner()) == (await provider.getSigner().getAddress())
 
   test "supports storage requests":
-    await token.approve(storage.address, request.ask.maxPrice)
+    await token.approve(storage.address, request.ask.reward)
     check (await market.requestStorage(request)) == request
 
   test "sets client address when submitting storage request":
     var requestWithoutClient = request
     requestWithoutClient.client = Address.default
-    await token.approve(storage.address, request.ask.maxPrice)
+    await token.approve(storage.address, request.ask.reward)
     let submitted = await market.requestStorage(requestWithoutClient)
     check submitted.client == accounts[0]
 
   test "can retrieve previously submitted requests":
     check (await market.getRequest(request.id)) == none StorageRequest
-    await token.approve(storage.address, request.ask.maxPrice)
+    await token.approve(storage.address, request.ask.reward)
     discard await market.requestStorage(request)
     check (await market.getRequest(request.id)) == some request
 
@@ -60,26 +60,26 @@ ethersuite "On-Chain Market":
       receivedIds.add(id)
       receivedAsks.add(ask)
     let subscription = await market.subscribeRequests(onRequest)
-    await token.approve(storage.address, request.ask.maxPrice)
+    await token.approve(storage.address, request.ask.reward)
     discard await market.requestStorage(request)
     check receivedIds == @[request.id]
     check receivedAsks == @[request.ask]
     await subscription.unsubscribe()
 
   test "supports fulfilling of requests":
-    await token.approve(storage.address, request.ask.maxPrice)
+    await token.approve(storage.address, request.ask.reward)
     discard await market.requestStorage(request)
     await market.fulfillRequest(request.id, proof)
 
   test "can retrieve host that fulfilled request":
-    await token.approve(storage.address, request.ask.maxPrice)
+    await token.approve(storage.address, request.ask.reward)
     discard await market.requestStorage(request)
     check (await market.getHost(request.id)) == none Address
     await market.fulfillRequest(request.id, proof)
     check (await market.getHost(request.id)) == some accounts[0]
 
   test "support fulfillment subscriptions":
-    await token.approve(storage.address, request.ask.maxPrice)
+    await token.approve(storage.address, request.ask.reward)
     discard await market.requestStorage(request)
     var receivedIds: seq[array[32, byte]]
     proc onFulfillment(id: array[32, byte]) =
@@ -93,9 +93,9 @@ ethersuite "On-Chain Market":
     var otherRequest = StorageRequest.example
     otherRequest.client = accounts[0]
 
-    await token.approve(storage.address, request.ask.maxPrice)
+    await token.approve(storage.address, request.ask.reward)
     discard await market.requestStorage(request)
-    await token.approve(storage.address, otherrequest.ask.maxPrice)
+    await token.approve(storage.address, otherrequest.ask.reward)
     discard await market.requestStorage(otherRequest)
 
     var receivedIds: seq[array[32, byte]]

--- a/tests/contracts/testMarket.nim
+++ b/tests/contracts/testMarket.nim
@@ -77,9 +77,9 @@ ethersuite "On-Chain Market":
   test "can retrieve host that filled slot":
     await token.approve(storage.address, request.price)
     discard await market.requestStorage(request)
-    check (await market.getHost(request.slotId(slotIndex))) == none Address
+    check (await market.getHost(request.id, slotIndex)) == none Address
     await market.fillSlot(request.id, slotIndex, proof)
-    check (await market.getHost(request.slotId(slotIndex))) == some accounts[0]
+    check (await market.getHost(request.id, slotIndex)) == some accounts[0]
 
   test "support fulfillment subscriptions":
     await token.approve(storage.address, request.price)

--- a/tests/testIntegration.nim
+++ b/tests/testIntegration.nim
@@ -62,19 +62,19 @@ ethersuite "Integration tests":
   test "node handles storage request":
     let cid = client.post(baseurl1 & "/upload", "some file contents").body
     let url = baseurl1 & "/storage/request/" & cid
-    let json = %*{"duration": "0x1", "maxPrice": "0x2"}
+    let json = %*{"duration": "0x1", "reward": "0x2"}
     let response = client.post(url, $json)
     check response.status == "200 OK"
 
   test "node retrieves purchase status":
     let cid = client.post(baseurl1 & "/upload", "some file contents").body
-    let request = %*{"duration": "0x1", "maxPrice": "0x2"}
+    let request = %*{"duration": "0x1", "reward": "0x2"}
     let id = client.post(baseurl1 & "/storage/request/" & cid, $request).body
     let response = client.get(baseurl1 & "/storage/purchases/" & id)
     check response.status == "200 OK"
     let json = parseJson(response.body)
     check json["request"]["ask"]["duration"].getStr == "0x1"
-    check json["request"]["ask"]["maxPrice"].getStr == "0x2"
+    check json["request"]["ask"]["reward"].getStr == "0x2"
 
   test "nodes negotiate contracts on the marketplace":
     proc sell =
@@ -89,7 +89,7 @@ ethersuite "Integration tests":
 
     proc buy(cid: string): string =
       let expiry = ((waitFor provider.currentTime()) + 30).toHex
-      let json = %*{"duration": "0x100", "maxPrice": "0x400", "expiry": expiry}
+      let json = %*{"duration": "0x100", "reward": "0x400", "expiry": expiry}
       client.post(baseurl1 & "/storage/request/" & cid, $json).body
 
     proc finish(purchase: string): Future[JsonNode] {.async.} =

--- a/tests/testIntegration.nim
+++ b/tests/testIntegration.nim
@@ -103,5 +103,4 @@ ethersuite "Integration tests":
     let purchase = waitFor upload().buy().finish()
 
     check purchase["error"].getStr == ""
-    check purchase["selected"].getStr == $accounts[1]
     check available().len == 0


### PR DESCRIPTION
Allows multiple slots in a storage contract, so that more than one host can contribute.

A step towards the design in https://github.com/status-im/codex-research/pull/83.
Uses the smart contract update from https://github.com/status-im/dagger-contracts/pull/13.
