### PR TITLE
Quickfix: start erasure decoding once any K blocks arrived

### DIFF
--- a/codex/erasure/erasure.nim
+++ b/codex/erasure/erasure.nim
@@ -200,7 +200,9 @@ proc decode*(
         resolved = 0
 
       while true:
-        if resolved >= (encoded.K + encoded.M) or idxPendingBlocks.len <= 0:
+        # Continue to receive blocks until we have just enough for decoding
+        # or no more blocks can arrive
+        if (resolved >= encoded.K) or (idxPendingBlocks.len == 0):
           break
 
         let


### PR DESCRIPTION
ECC decoding can be done with any encoded.K blocks, and now we start it once any K blocks arrived.

Previous code essentially waited for all blocks to arrive (or fail to arrive), that may mean unnecessary delays.

New code will sometimes ECC-decode when parity blocks were retrieved faster that data blocks (instead of waiting for data blocks from network), but we expect that it's OK due to extremely fast Leopard decoding (~~500 MB/s)