### PR TITLE
ALT PR: update getBlock return type

### DIFF
--- a/codex/blockexchange/engine/engine.nim
+++ b/codex/blockexchange/engine/engine.nim
@@ -379,8 +379,8 @@ proc taskHandler*(b: BlockExcEngine, task: BlockExcPeerCtx) {.gcsafe, async.} =
 
     # Extract succesfully received blocks
     let blocks = blockFuts
-      .filterIt(it.completed and it.read.isOk and it.read.get.isSome)
-      .mapIt(it.read.get.get)
+      .filterIt(it.completed and it.read.isOk)
+      .mapIt(it.read.get)
 
     if blocks.len > 0:
       trace "Sending blocks to peer", peer = task.id, blocks = blocks.len

--- a/codex/blocktype.nim
+++ b/codex/blocktype.nim
@@ -29,6 +29,18 @@ type
     cid*: Cid
     data*: seq[byte]
 
+  BlockErrorKind* = enum
+    BlockConstructErr,
+    BlockKeyErr,
+    BlockNetReqErr,
+    BlockNotFoundErr,
+    BlockReadErr
+
+  BlockError* = object of CodexError
+    kind*: BlockErrorKind
+
+  BlockResult* = Result[Block, ref BlockError]
+
 template EmptyCid*: untyped =
   var
     emptyCid {.global, threadvar.}:

--- a/codex/stores/blockstore.nim
+++ b/codex/stores/blockstore.nim
@@ -24,7 +24,7 @@ type
   OnBlock* = proc(cid: Cid): Future[void] {.upraises: [], gcsafe.}
   BlockStore* = ref object of RootObj
 
-method getBlock*(self: BlockStore, cid: Cid): Future[?! (? Block)] {.base.} =
+method getBlock*(self: BlockStore, cid: Cid): Future[BlockResult] {.base.} =
   ## Get a block from the blockstore
   ##
 

--- a/codex/stores/cachestore.nim
+++ b/codex/stores/cachestore.nim
@@ -43,24 +43,24 @@ const
   DefaultCacheSizeMiB* = 100
   DefaultCacheSize* = DefaultCacheSizeMiB * MiB # bytes
 
-method getBlock*(self: CacheStore, cid: Cid): Future[?! (? Block)] {.async.} =
+method getBlock*(self: CacheStore, cid: Cid): Future[BlockResult] {.async.} =
   ## Get a block from the stores
   ##
 
   trace "Getting block from cache", cid
+
   if cid.isEmpty:
     trace "Empty block, ignoring"
-    return cid.emptyBlock.some.success
+    return ok cid.emptyBlock
 
   if cid notin self.cache:
-    return Block.none.success
+    return failure (ref BlockError)(kind: BlockNotFoundErr, msg: "Block not in cache")
 
   try:
-    let blk = self.cache[cid]
-    return blk.some.success
+    return ok self.cache[cid]
   except CatchableError as exc:
-    trace "Exception requesting block", cid, exc = exc.msg
-    return failure(exc)
+    trace "Error requesting block from cache", cid, error = exc.msg
+    return failure (ref BlockError)(kind: BlockReadErr, msg: exc.msg)
 
 method hasBlock*(self: CacheStore, cid: Cid): Future[?!bool] {.async.} =
   ## Check if the block exists in the blockstore

--- a/codex/stores/fsstore.nim
+++ b/codex/stores/fsstore.nim
@@ -37,46 +37,70 @@ type
 template blockPath*(self: FSStore, cid: Cid): string =
   self.repoDir / ($cid)[^self.postfixLen..^1] / $cid
 
-method getBlock*(self: FSStore, cid: Cid): Future[?! (? Block)] {.async.} =
-  ## Get a block from the stores
+method getBlock*(self: FSStore, cid: Cid): Future[BlockResult] {.async.} =
+  ## Get a block from the cache or filestore.
+  ## Save a copy to the cache if present in the filestore but not in the cache
   ##
 
-  trace "Getting block from filestore", cid
+  if not self.cache.isNil:
+    trace "Getting block from cache or filestore", cid
+  else:
+    trace "Getting block from filestore", cid
+
   if cid.isEmpty:
     trace "Empty block, ignoring"
-    return cid.emptyBlock.some.success
+    return ok cid.emptyBlock
 
-  let cachedBlock = await self.cache.getBlock(cid)
-  if cachedBlock.isErr:
-    return cachedBlock
-  if cachedBlock.get.isSome:
-    trace "Retrieved block from cache", cid
-    return cachedBlock
+  if not self.cache.isNil:
+    let
+      cachedBlockRes = await self.cache.getBlock(cid)
+
+    if not cachedBlockRes.isErr:
+      return ok cachedBlockRes.get
+    else:
+      trace "Unable to read block from cache", cid, error = cachedBlockRes.error.msg
 
   # Read file contents
-  var data: seq[byte]
+  var
+    data: seq[byte]
+
   let
     path = self.blockPath(cid)
     res = io2.readFile(path, data)
 
   if res.isErr:
     if not isFile(path):   # May be, check instead that "res.error == ERROR_FILE_NOT_FOUND" ?
-      return Block.none.success
+      return failure (ref BlockError)(kind: BlockNotFoundErr, msg: "Block not in filestore")
     else:
-      let error = io2.ioErrorMsg(res.error)
-      trace "Cannot read file from filestore", path, error
-      return failure("Cannot read file from filestore")
+      let
+        error = io2.ioErrorMsg(res.error)
 
-  without var blk =? Block.new(cid, data), error:
-    return error.failure
+      trace "Error requesting block from filestore", path, error
+      return failure (ref BlockError)(
+        kind: BlockReadErr, msg: "Error requesting block from filestore: " & error)
 
-  # TODO: add block to the cache
-  return blk.some.success
+  without blk =? Block.new(cid, data), error:
+    trace "Unable to construct block from data", cid, error = error.msg
+    return failure (ref BlockError)(kind: BlockConstructErr, msg: error.msg)
+
+  if not self.cache.isNil:
+    let
+      putCachedRes = await self.cache.putBlock(blk)
+
+    if putCachedRes.isErr:
+      trace "Unable to store block in cache", cid, error = putCachedRes.error.msg
+
+  return ok blk
 
 method putBlock*(self: FSStore, blk: Block): Future[?!void] {.async.} =
-  ## Write block contents to file with name based on blk.cid,
-  ## save second copy to the cache
+  ## Write a block's contents to a file with name based on blk.cid.
+  ## Save a copy to the cache
   ##
+
+  if not self.cache.isNil:
+    trace "Putting block into filestore and cache", cid = blk.cid
+  else:
+    trace "Putting block into filestore", cid = blk.cid
 
   if blk.isEmpty:
     trace "Empty block, ignoring"
@@ -98,19 +122,34 @@ method putBlock*(self: FSStore, blk: Block): Future[?!void] {.async.} =
     trace "Unable to store block", path, cid = blk.cid, error
     return failure("Unable to store block")
 
-  if isErr (await self.cache.putBlock(blk)):
-    trace "Unable to store block in cache", cid = blk.cid
+  if not self.cache.isNil:
+    let
+      putCachedRes = await self.cache.putBlock(blk)
+
+    if putCachedRes.isErr:
+      trace "Unable to store block in cache", cid = blk.cid, error = putCachedRes.error.msg
 
   return success()
 
 method delBlock*(self: FSStore, cid: Cid): Future[?!void] {.async.} =
-  ## Delete a block from the blockstore
+  ## Delete a block from the cache and filestore
   ##
 
-  trace "Deleting block from filestore", cid
+  if not self.cache.isNil:
+    trace "Deleting block from cache and filestore", cid
+  else:
+    trace "Deleting block from filestore", cid
+
   if cid.isEmpty:
     trace "Empty block, ignoring"
     return success()
+
+  if not self.cache.isNil:
+    let
+      delCachedRes = await self.cache.delBlock(cid)
+
+    if delCachedRes.isErr:
+      trace "Unable to delete block from cache", cid, error = delCachedRes.error.msg
 
   let
     path = self.blockPath(cid)
@@ -121,10 +160,10 @@ method delBlock*(self: FSStore, cid: Cid): Future[?!void] {.async.} =
     trace "Unable to delete block", path, cid, error
     return error.failure
 
-  return await self.cache.delBlock(cid)
+  return success()
 
 method hasBlock*(self: FSStore, cid: Cid): Future[?!bool] {.async.} =
-  ## Check if the block exists in the blockstore
+  ## Check if a block exists in the filestore
   ##
 
   trace "Checking filestore for block existence", cid
@@ -135,7 +174,8 @@ method hasBlock*(self: FSStore, cid: Cid): Future[?!bool] {.async.} =
   return self.blockPath(cid).isFile().success
 
 method listBlocks*(self: FSStore, onBlock: OnBlock): Future[?!void] {.async.} =
-  ## Get the list of blocks in the BlockStore. This is an intensive operation
+  ## Process list of all blocks in the filestore via callback.
+  ## This is an intensive operation
   ##
 
   trace "Listing all blocks in filestore"

--- a/codex/streams/storestream.nim
+++ b/codex/streams/storestream.nim
@@ -81,10 +81,14 @@ method readOnce*(
       readBytes   = min(nbytes - read, self.manifest.blockSize - blockOffset)
 
     # Read contents of block `blockNum`
-    without blkOrNone =? await self.store.getBlock(self.manifest[blockNum]), error:
-      raise newLPStreamReadError(error)
-    without blk =? blkOrNone:
-      raise newLPStreamReadError("Block not found")
+    let
+      getRes = await self.store.getBlock(self.manifest[blockNum])
+
+    if getRes.isErr: raise newLPStreamReadError(getRes.error)
+
+    let
+      blk = getRes.get
+
     trace "Reading bytes from store stream", blockNum, cid = blk.cid, bytes = readBytes, blockOffset
 
     # Copy `readBytes` bytes starting at `blockOffset` from the block into the outbuf

--- a/tests/codex/blockexchange/engine/testblockexc.nim
+++ b/tests/codex/blockexchange/engine/testblockexc.nim
@@ -126,7 +126,7 @@ suite "NetworkStore engine - 2 nodes":
   test "Should get blocks from remote":
     let blocks = await allFinished(
       blocks2.mapIt( nodeCmps1.networkStore.getBlock(it.cid) ))
-    check blocks.mapIt( it.read().tryGet().get() ) == blocks2
+    check blocks.mapIt( it.read().tryGet() ) == blocks2
 
   test "Remote should send blocks when available":
     let blk = bt.Block.new("Block 1".toBytes).tryGet()

--- a/tests/codex/helpers.nim
+++ b/tests/codex/helpers.nim
@@ -47,7 +47,7 @@ proc corruptBlocks*(
 
     pos.add(i)
     var
-      blk = (await store.getBlock(manifest[i])).tryGet().get()
+      blk = (await store.getBlock(manifest[i])).tryGet()
       bytePos: seq[int]
 
     while true:

--- a/tests/codex/stores/testcachestore.nim
+++ b/tests/codex/stores/testcachestore.nim
@@ -72,11 +72,13 @@ suite "Cache Store":
     store = CacheStore.new(@[newBlock])
 
     let blk = await store.getBlock(newBlock.cid)
-    check blk.tryGet().get() == newBlock
+    check blk.tryGet() == newBlock
 
   test "fail getBlock":
     let blk = await store.getBlock(newBlock.cid)
-    check blk.tryGet().isNone()
+    check:
+      blk.isErr
+      blk.error.kind == BlockNotFoundErr
 
   test "hasBlock":
     let store = CacheStore.new(@[newBlock])

--- a/tests/codex/stores/testsqlitestore.nim
+++ b/tests/codex/stores/testsqlitestore.nim
@@ -43,7 +43,7 @@ proc runSuite(cache: bool) =
       if cache:
         store = SQLiteStore.new(repoDir)
       else:
-        store = SQLiteStore.new(repoDir, nil)
+        store = SQLiteStore.new(repoDir, cache = nil)
 
       newBlock = randomBlock()
 
@@ -132,37 +132,24 @@ proc runSuite(cache: bool) =
         # get from database
         getRes = await store.getBlock(newBlock.cid)
 
-      check: getRes.isOk
-
-      var
-        blkOpt = getRes.get
-
       check:
-        blkOpt.isSome
-        blkOpt.get == newBlock
+        getRes.isOk
+        getRes.get == newBlock
 
       # get from enabled cache
       getRes = await store.getBlock(newBlock.cid)
 
-      check: getRes.isOk
-
-      blkOpt = getRes.get
-
       check:
-        blkOpt.isSome
-        blkOpt.get == newBlock
+        getRes.isOk
+        getRes.get == newBlock
 
     test "fail getBlock":
       let
-        getRes = await store.getBlock(newBlock.cid)
+        blkRes = await store.getBlock(newBlock.cid)
 
-      assert getRes.isOk
-
-      let
-        blkOpt = getRes.get
-
-      check: blkOpt.isNone
-
+      check:
+        blkRes.isErr
+        blkRes.error.kind == BlockNotFoundErr
 
     test "hasBlock":
       let

--- a/tests/codex/testnode.nim
+++ b/tests/codex/testnode.nim
@@ -158,7 +158,7 @@ suite "Test Node":
       (await localStore.hasBlock(manifestCid)).tryGet()
 
     var
-      manifestBlock = (await localStore.getBlock(manifestCid)).tryGet().get()
+      manifestBlock = (await localStore.getBlock(manifestCid)).tryGet()
       localManifest = Manifest.decode(manifestBlock).tryGet()
 
     check:


### PR DESCRIPTION
Change return type for `method getBlock` from `Future[?!(?Block)]` to `Future[BlockResult]`.

Also make some logic and error handling/messages more consistent across `BlockStore` implementations.

Closes #177.
Closes #182.

Alternative to #205.

---

This PR is an alternative to #205 per discussion under https://github.com/status-im/nim-codex/pull/205#issuecomment-1210864052.

I ran into some difficulties while working on this. My initial idea was to use `when...is` to discriminate return types, but I wasn't able to get that to work. I may have missed/misunderstood something re: what Nim allows for, so what I write below can possibly be disregarded, and/or the changes in this PR can possibly be reworked into something more desirable. Also, what I observed may be reducible to *"that's how Nim's type system works"*, but it wasn't obvious to me before I started experimenting, in which case it's a good learning experience, though in hindsight I saw something similar in #200 where I [noted](https://github.com/status-im/nim-codex/pull/200#issuecomment-1205899757) `Option[BlockStore] isnot Option[CacheStore]`.

My approach was to take the changes in #205 and rework them so that different error types can represent different conditions, and thereby callers can decide to behave differently depending on the error type.

That proved to be problematic for return types involving `Result[T, E]`, which are precisely what we're working with. Given types `BlockNotFoundError = ref object of BlockError` and `BlockReadError = ref object of BlockError`, both descending from `BlockError = ref object of CodexError`, it wasn't possible to use `when...is` in the caller to distinguish the error types given a return type of `Result[Block, ref BlockError]`.

I tried using type constructs such as `BlockNotFoundError | BlockReadError`, but in the context of `Result[...]` that doesn't work either.

What I ultimately did was introduce a `kind` field on `type BlockError`, which leverages `type BlockErrorKind = enum ...` so that errors can be discriminated at runtime.

That works! But it has a number of implications:

We need several `enum` members to distinguish different kinds of errors, versus using two distinctions (`some` or `none`) for different kinds of values in `Result[...]`

I spec'd these:
```nim
type
  BlockErrorKind* = enum
    BlockConstructErr,
    BlockKeyErr,
    BlockNetReqErr,
    BlockNotFoundErr,
    BlockReadErr
```

For our purposes at present, those could be reduced to:
```nim
type
  BlockErrorKind* = enum
    BlockNotFoundErr,
    BlockOtherErr,
    BlockReadErr
```

But adding an `enum` member seems cheap, i.e. compared to the other trade-offs of this PR vs. #205.

Our preferred error-handling library [`status-im/questionable`](https://github.com/status-im/questionable) makes some (pretty natural) assumptions such that return type `BlockResult = Result[Block, ref BlockError]` becomes problematic. The `without` helper becomes unusable for such return types, and it's necessary to use `ok` from `stew/results` instead of questionable's `success` because of a problem (undiagnosed) in combination with nim-chronos' `complete`. It's also sometimes necessary to be more verbose when using questionable's `failure`, i.e. `failure (ref BlockError)(kind: ..., msg: ...)`.

Those incompatibilities ripple outward, so more changes have to be made in this PR vs. #205.

It may be possible to resolve all these problems in an elegant manner, and as I suggested at the start, some of the problems may owe to my not considering other possibilities.

I look forward to discussion, but my current impression is that we should close this PR and stick with #205, or close #205 ***and*** this PR, sticking with `Future[?!(?Block)]`, though in the latter case there are some changes in this PR and #205 re: #177 that are worthwhile and can/should be extracted into a future PR.