### PR TITLE
[chore] clean up `array[32, byte]` types

### DIFF
--- a/codex/contracts/market.nim
+++ b/codex/contracts/market.nim
@@ -35,7 +35,7 @@ method requestStorage(market: OnChainMarket,
   return request
 
 method getRequest(market: OnChainMarket,
-                  id: array[32, byte]): Future[?StorageRequest] {.async.} =
+                  id: RequestId): Future[?StorageRequest] {.async.} =
   let request = await market.contract.getRequest(id)
   if request != StorageRequest.default:
     return some request
@@ -43,7 +43,7 @@ method getRequest(market: OnChainMarket,
     return none StorageRequest
 
 method getHost(market: OnChainMarket,
-               requestId: array[32, byte],
+               requestId: RequestId,
                slotIndex: UInt256): Future[?Address] {.async.} =
   let slotId = slotId(requestId, slotIndex)
   let address = await market.contract.getHost(slotId)
@@ -53,7 +53,7 @@ method getHost(market: OnChainMarket,
     return none Address
 
 method fillSlot(market: OnChainMarket,
-                requestId: array[32, byte],
+                requestId: RequestId,
                 slotIndex: UInt256,
                 proof: seq[byte]) {.async.} =
   await market.contract.fillSlot(requestId, slotIndex, proof)
@@ -67,7 +67,7 @@ method subscribeRequests(market: OnChainMarket,
   return OnChainMarketSubscription(eventSubscription: subscription)
 
 method subscribeSlotFilled*(market: OnChainMarket,
-                            requestId: array[32, byte],
+                            requestId: RequestId,
                             slotIndex: UInt256,
                             callback: OnSlotFilled):
                            Future[MarketSubscription] {.async.} =
@@ -78,7 +78,7 @@ method subscribeSlotFilled*(market: OnChainMarket,
   return OnChainMarketSubscription(eventSubscription: subscription)
 
 method subscribeFulfillment(market: OnChainMarket,
-                            requestId: array[32, byte],
+                            requestId: RequestId,
                             callback: OnFulfillment):
                            Future[MarketSubscription] {.async.} =
   proc onEvent(event: RequestFulfilled) {.upraises:[].} =

--- a/codex/contracts/proofs.nim
+++ b/codex/contracts/proofs.nim
@@ -23,19 +23,19 @@ method periodicity*(proofs: OnChainProofs): Future[Periodicity] {.async.} =
   return Periodicity(seconds: period)
 
 method isProofRequired*(proofs: OnChainProofs,
-                        id: ContractId): Future[bool] {.async.} =
+                        id: SlotId): Future[bool] {.async.} =
   return await proofs.storage.isProofRequired(id)
 
 method willProofBeRequired*(proofs: OnChainProofs,
-                            id: ContractId): Future[bool] {.async.} =
+                            id: SlotId): Future[bool] {.async.} =
   return await proofs.storage.willProofBeRequired(id)
 
 method getProofEnd*(proofs: OnChainProofs,
-                    id: ContractId): Future[UInt256] {.async.} =
+                    id: SlotId): Future[UInt256] {.async.} =
   return await proofs.storage.proofEnd(id)
 
 method submitProof*(proofs: OnChainProofs,
-                    id: ContractId,
+                    id: SlotId,
                     proof: seq[byte]) {.async.} =
   await proofs.storage.submitProof(id, proof)
 

--- a/codex/contracts/requests.nim
+++ b/codex/contracts/requests.nim
@@ -11,7 +11,7 @@ type
     ask*: StorageAsk
     content*: StorageContent
     expiry*: UInt256
-    nonce*: array[32, byte]
+    nonce*: Nonce
   StorageAsk* = object
     slots*: uint64
     slotSize*: UInt256
@@ -28,6 +28,9 @@ type
     u*: seq[byte]
     publicKey*: seq[byte]
     name*: seq[byte]
+  SlotId* = array[32, byte]
+  RequestId* = array[32, byte]
+  Nonce* = array[32, byte]
 
 func fromTuple(_: type StorageRequest, tupl: tuple): StorageRequest =
   StorageRequest(
@@ -116,15 +119,15 @@ func decode*(decoder: var AbiDecoder, T: type StorageRequest): ?!T =
   let tupl = ?decoder.read(StorageRequest.fieldTypes)
   success StorageRequest.fromTuple(tupl)
 
-func id*(request: StorageRequest): array[32, byte] =
+func id*(request: StorageRequest): RequestId =
   let encoding = AbiEncoder.encode((request, ))
   keccak256.digest(encoding).data
 
-func slotId*(requestId: array[32, byte], slot: UInt256): array[32, byte] =
+func slotId*(requestId: RequestId, slot: UInt256): SlotId =
   let encoding = AbiEncoder.encode((requestId, slot))
   keccak256.digest(encoding).data
 
-func slotId*(request: StorageRequest, slot: UInt256): array[32, byte] =
+func slotId*(request: StorageRequest, slot: UInt256): SlotId =
   slotId(request.id, slot)
 
 func pricePerSlot*(ask: StorageAsk): UInt256 =

--- a/codex/contracts/storage.nim
+++ b/codex/contracts/storage.nim
@@ -9,18 +9,18 @@ export ethers
 
 type
   Storage* = ref object of Contract
-  Id = array[32, byte]
   StorageRequested* = object of Event
-    requestId*: Id
+    requestId*: RequestId
     ask*: StorageAsk
   SlotFilled* = object of Event
-    requestId* {.indexed.}: Id
+    requestId* {.indexed.}: RequestId
     slotIndex* {.indexed.}: UInt256
-    slotId* {.indexed.}: Id
+    slotId* {.indexed.}: SlotId
   RequestFulfilled* = object of Event
-    requestId* {.indexed.}: Id
+    requestId* {.indexed.}: RequestId
+
   ProofSubmitted* = object of Event
-    id*: Id
+    id*: SlotId
     proof*: seq[byte]
 
 
@@ -33,22 +33,20 @@ proc withdraw*(storage: Storage) {.contract.}
 proc balanceOf*(storage: Storage, account: Address): UInt256 {.contract, view.}
 
 proc requestStorage*(storage: Storage, request: StorageRequest) {.contract.}
-proc fillSlot*(storage: Storage, requestId: Id, slotIndex: UInt256, proof: seq[byte]) {.contract.}
-proc payoutSlot*(storage: Storage, requestId: Id, slotIndex: UInt256) {.contract.}
-proc getRequest*(storage: Storage, id: Id): StorageRequest {.contract, view.}
-proc getHost*(storage: Storage, id: Id): Address {.contract, view.}
-
-proc finishContract*(storage: Storage, id: Id) {.contract.}
+proc fillSlot*(storage: Storage, requestId: RequestId, slotIndex: UInt256, proof: seq[byte]) {.contract.}
+proc payoutSlot*(storage: Storage, requestId: RequestId, slotIndex: UInt256) {.contract.}
+proc getRequest*(storage: Storage, id: RequestId): StorageRequest {.contract, view.}
+proc getHost*(storage: Storage, id: SlotId): Address {.contract, view.}
 
 proc proofPeriod*(storage: Storage): UInt256 {.contract, view.}
 proc proofTimeout*(storage: Storage): UInt256 {.contract, view.}
 
-proc proofEnd*(storage: Storage, id: Id): UInt256 {.contract, view.}
-proc missingProofs*(storage: Storage, id: Id): UInt256 {.contract, view.}
-proc isProofRequired*(storage: Storage, id: Id): bool {.contract, view.}
-proc willProofBeRequired*(storage: Storage, id: Id): bool {.contract, view.}
-proc getChallenge*(storage: Storage, id: Id): array[32, byte] {.contract, view.}
-proc getPointer*(storage: Storage, id: Id): uint8 {.contract, view.}
+proc proofEnd*(storage: Storage, id: SlotId): UInt256 {.contract, view.}
+proc missingProofs*(storage: Storage, id: SlotId): UInt256 {.contract, view.}
+proc isProofRequired*(storage: Storage, id: SlotId): bool {.contract, view.}
+proc willProofBeRequired*(storage: Storage, id: SlotId): bool {.contract, view.}
+proc getChallenge*(storage: Storage, id: SlotId): array[32, byte] {.contract, view.}
+proc getPointer*(storage: Storage, id: SlotId): uint8 {.contract, view.}
 
-proc submitProof*(storage: Storage, id: Id, proof: seq[byte]) {.contract.}
-proc markProofAsMissing*(storage: Storage, id: Id, period: UInt256) {.contract.}
+proc submitProof*(storage: Storage, id: SlotId, proof: seq[byte]) {.contract.}
+proc markProofAsMissing*(storage: Storage, id: SlotId, period: UInt256) {.contract.}

--- a/codex/market.nim
+++ b/codex/market.nim
@@ -10,9 +10,9 @@ export requests
 type
   Market* = ref object of RootObj
   Subscription* = ref object of RootObj
-  OnRequest* = proc(id: array[32, byte], ask: StorageAsk) {.gcsafe, upraises:[].}
-  OnFulfillment* = proc(requestId: array[32, byte]) {.gcsafe, upraises: [].}
-  OnSlotFilled* = proc(requestId: array[32, byte], slotIndex: UInt256) {.gcsafe, upraises:[].}
+  OnRequest* = proc(id: RequestId, ask: StorageAsk) {.gcsafe, upraises:[].}
+  OnFulfillment* = proc(requestId: RequestId) {.gcsafe, upraises: [].}
+  OnSlotFilled* = proc(requestId: RequestId, slotIndex: UInt256) {.gcsafe, upraises:[].}
 
 method getSigner*(market: Market): Future[Address] {.base, async.} =
   raiseAssert("not implemented")
@@ -23,17 +23,17 @@ method requestStorage*(market: Market,
   raiseAssert("not implemented")
 
 method getRequest*(market: Market,
-                   id: array[32, byte]):
+                   id: RequestId):
                   Future[?StorageRequest] {.base, async.} =
   raiseAssert("not implemented")
 
 method getHost*(market: Market,
-                requestId: array[32, byte],
+                requestId: RequestId,
                 slotIndex: UInt256): Future[?Address] {.base, async.} =
   raiseAssert("not implemented")
 
 method fillSlot*(market: Market,
-                 requestId: array[32, byte],
+                 requestId: RequestId,
                  slotIndex: UInt256,
                  proof: seq[byte]) {.base, async.} =
   raiseAssert("not implemented")
@@ -44,13 +44,13 @@ method subscribeRequests*(market: Market,
   raiseAssert("not implemented")
 
 method subscribeFulfillment*(market: Market,
-                             requestId: array[32, byte],
+                             requestId: RequestId,
                              callback: OnFulfillment):
                             Future[Subscription] {.base, async.} =
   raiseAssert("not implemented")
 
 method subscribeSlotFilled*(market: Market,
-                            requestId: array[32, byte],
+                            requestId: RequestId,
                             slotIndex: UInt256,
                             callback: OnSlotFilled):
                            Future[Subscription] {.base, async.} =

--- a/codex/node.nim
+++ b/codex/node.nim
@@ -221,7 +221,7 @@ proc requestStorage*(self: CodexNodeRef,
                      nodes: uint,
                      tolerance: uint,
                      reward: UInt256,
-                     expiry = UInt256.none): Future[?!array[32, byte]] {.async.} =
+                     expiry = UInt256.none): Future[?!PurchaseId] {.async.} =
   ## Initiate a request for storage sequence, this might
   ## be a multistep procedure.
   ##

--- a/codex/purchasing.nim
+++ b/codex/purchasing.nim
@@ -32,7 +32,9 @@ proc start(purchase: Purchase) {.gcsafe.}
 func id*(purchase: Purchase): PurchaseId
 proc `==`*(x, y: PurchaseId): bool {.borrow.}
 proc hash*(x: PurchaseId): Hash {.borrow.}
-proc toHex*(x: PurchaseId): string {.borrow.}
+# Using {.borrow.} for toHex does not borrow correctly and causes a
+# C-compilation error, so we must do it long form
+proc toHex*(x: PurchaseId): string = array[32, byte](x).toHex
 
 proc new*(_: type Purchasing, market: Market, clock: Clock): Purchasing =
   Purchasing(

--- a/codex/rest/api.nim
+++ b/codex/rest/api.nim
@@ -305,7 +305,7 @@ proc initRestApi*(node: CodexNodeRef, conf: CodexConf): RestRouter =
   router.api(
     MethodGet,
     "/api/codex/v1/storage/purchases/{id}") do (
-      id: array[32, byte]) -> RestApiResponse:
+      id: PurchaseId) -> RestApiResponse:
 
       without contracts =? node.contracts:
         return RestApiResponse.error(Http503, "Purchasing unavailable")

--- a/codex/rest/api.nim
+++ b/codex/rest/api.nim
@@ -13,6 +13,7 @@ push: {.upraises: [].}
 
 
 import std/sequtils
+import std/sugar
 
 import pkg/questionable
 import pkg/questionable/results
@@ -103,6 +104,10 @@ proc decodeString(_: type array[32, byte],
     ok array[32, byte].fromHex(value)
   except ValueError as e:
     err e.msg.cstring
+
+proc decodeString[T: PurchaseId | RequestId | Nonce](_: type T,
+                  value: string): Result[T, cstring] =
+  array[32, byte].decodeString(value).map(id => T(id))
 
 proc initRestApi*(node: CodexNodeRef, conf: CodexConf): RestRouter =
   var router = RestRouter.init(validate)

--- a/codex/rest/json.nim
+++ b/codex/rest/json.nim
@@ -45,6 +45,9 @@ func `%`*(stint: StInt|StUInt): JsonNode =
 func `%`*(arr: openArray[byte]): JsonNode =
   %("0x" & arr.toHex)
 
+func `%`*(id: RequestId | SlotId | Nonce): JsonNode =
+  % id.toArray
+
 func `%`*(purchase: Purchase): JsonNode =
   %*{
     "finished": purchase.finished,

--- a/codex/storageproofs/timing/proofs.nim
+++ b/codex/storageproofs/timing/proofs.nim
@@ -2,35 +2,36 @@ import pkg/chronos
 import pkg/stint
 import pkg/upraises
 import ./periods
+from ../../contracts/requests import SlotId, RequestId
 
 export chronos
 export stint
 export periods
+export SlotId, RequestId
 
 type
   Proofs* = ref object of RootObj
   Subscription* = ref object of RootObj
-  OnProofSubmitted* = proc(id: ContractId, proof: seq[byte]) {.gcsafe, upraises:[].}
-  ContractId* = array[32, byte]
+  OnProofSubmitted* = proc(id: SlotId, proof: seq[byte]) {.gcsafe, upraises:[].}
 
 method periodicity*(proofs: Proofs):
                    Future[Periodicity] {.base, async.} =
   raiseAssert("not implemented")
 
 method isProofRequired*(proofs: Proofs,
-                        id: ContractId): Future[bool] {.base, async.} =
+                        id: SlotId): Future[bool] {.base, async.} =
   raiseAssert("not implemented")
 
 method willProofBeRequired*(proofs: Proofs,
-                            id: ContractId): Future[bool] {.base, async.} =
+                            id: SlotId): Future[bool] {.base, async.} =
   raiseAssert("not implemented")
 
 method getProofEnd*(proofs: Proofs,
-                    id: ContractId): Future[UInt256] {.base, async.} =
+                    id: SlotId): Future[UInt256] {.base, async.} =
   raiseAssert("not implemented")
 
 method submitProof*(proofs: Proofs,
-                    id: ContractId,
+                    id: SlotId,
                     proof: seq[byte]) {.base, async.} =
   raiseAssert("not implemented")
 

--- a/codex/storageproofs/timing/proofs.nim
+++ b/codex/storageproofs/timing/proofs.nim
@@ -2,12 +2,12 @@ import pkg/chronos
 import pkg/stint
 import pkg/upraises
 import ./periods
-from ../../contracts/requests import SlotId, RequestId
+import ../../contracts/requests
 
 export chronos
 export stint
 export periods
-export SlotId, RequestId
+export requests
 
 type
   Proofs* = ref object of RootObj

--- a/tests/codex/helpers/mockproofs.nim
+++ b/tests/codex/helpers/mockproofs.nim
@@ -7,9 +7,9 @@ import pkg/codex/storageproofs
 type
   MockProofs* = ref object of Proofs
     periodicity: Periodicity
-    proofsRequired: HashSet[ContractId]
-    proofsToBeRequired: HashSet[ContractId]
-    proofEnds: Table[ContractId, UInt256]
+    proofsRequired: HashSet[SlotId]
+    proofsToBeRequired: HashSet[SlotId]
+    proofEnds: Table[SlotId, UInt256]
     subscriptions: seq[MockSubscription]
   MockSubscription* = ref object of Subscription
     proofs: MockProofs
@@ -26,38 +26,38 @@ func setPeriodicity*(mock: MockProofs, periodicity: Periodicity) =
 method periodicity*(mock: MockProofs): Future[Periodicity] {.async.} =
   return mock.periodicity
 
-proc setProofRequired*(mock: MockProofs, id: ContractId, required: bool) =
+proc setProofRequired*(mock: MockProofs, id: SlotId, required: bool) =
   if required:
     mock.proofsRequired.incl(id)
   else:
     mock.proofsRequired.excl(id)
 
 method isProofRequired*(mock: MockProofs,
-                        id: ContractId): Future[bool] {.async.} =
+                        id: SlotId): Future[bool] {.async.} =
   return mock.proofsRequired.contains(id)
 
-proc setProofToBeRequired*(mock: MockProofs, id: ContractId, required: bool) =
+proc setProofToBeRequired*(mock: MockProofs, id: SlotId, required: bool) =
   if required:
     mock.proofsToBeRequired.incl(id)
   else:
     mock.proofsToBeRequired.excl(id)
 
 method willProofBeRequired*(mock: MockProofs,
-                            id: ContractId): Future[bool] {.async.} =
+                            id: SlotId): Future[bool] {.async.} =
   return mock.proofsToBeRequired.contains(id)
 
-proc setProofEnd*(mock: MockProofs, id: ContractId, proofEnd: UInt256) =
+proc setProofEnd*(mock: MockProofs, id: SlotId, proofEnd: UInt256) =
   mock.proofEnds[id] = proofEnd
 
 method getProofEnd*(mock: MockProofs,
-                    id: ContractId): Future[UInt256] {.async.} =
+                    id: SlotId): Future[UInt256] {.async.} =
   if mock.proofEnds.hasKey(id):
     return mock.proofEnds[id]
   else:
     return UInt256.high
 
 method submitProof*(mock: MockProofs,
-                    id: ContractId,
+                    id: SlotId,
                     proof: seq[byte]) {.async.} =
   for subscription in mock.subscriptions:
     subscription.callback(id, proof)

--- a/tests/codex/testproving.nim
+++ b/tests/codex/testproving.nim
@@ -26,25 +26,25 @@ suite "Proving":
     await sleepAsync(2.seconds)
 
   test "maintains a list of contract ids to watch":
-    let id1, id2 = ContractId.example
-    check proving.contracts.len == 0
+    let id1, id2 = SlotId.example
+    check proving.slots.len == 0
     proving.add(id1)
-    check proving.contracts.contains(id1)
+    check proving.slots.contains(id1)
     proving.add(id2)
-    check proving.contracts.contains(id1)
-    check proving.contracts.contains(id2)
+    check proving.slots.contains(id1)
+    check proving.slots.contains(id2)
 
   test "removes duplicate contract ids":
-    let id = ContractId.example
+    let id = SlotId.example
     proving.add(id)
     proving.add(id)
-    check proving.contracts.len == 1
+    check proving.slots.len == 1
 
   test "invokes callback when proof is required":
-    let id = ContractId.example
+    let id = SlotId.example
     proving.add(id)
     var called: bool
-    proc onProofRequired(id: ContractId) =
+    proc onProofRequired(id: SlotId) =
       called = true
     proving.onProofRequired = onProofRequired
     proofs.setProofRequired(id, true)
@@ -52,11 +52,11 @@ suite "Proving":
     check called
 
   test "callback receives id of contract for which proof is required":
-    let id1, id2 = ContractId.example
+    let id1, id2 = SlotId.example
     proving.add(id1)
     proving.add(id2)
-    var callbackIds: seq[ContractId]
-    proc onProofRequired(id: ContractId) =
+    var callbackIds: seq[SlotId]
+    proc onProofRequired(id: SlotId) =
       callbackIds.add(id)
     proving.onProofRequired = onProofRequired
     proofs.setProofRequired(id1, true)
@@ -68,10 +68,10 @@ suite "Proving":
     check callbackIds == @[id1, id2]
 
   test "invokes callback when proof is about to be required":
-    let id = ContractId.example
+    let id = SlotId.example
     proving.add(id)
     var called: bool
-    proc onProofRequired(id: ContractId) =
+    proc onProofRequired(id: SlotId) =
       called = true
     proving.onProofRequired = onProofRequired
     proofs.setProofRequired(id, false)
@@ -80,12 +80,12 @@ suite "Proving":
     check called
 
   test "stops watching when contract has ended":
-    let id = ContractId.example
+    let id = SlotId.example
     proving.add(id)
     proofs.setProofEnd(id, clock.now().u256)
     await proofs.advanceToNextPeriod()
     var called: bool
-    proc onProofRequired(id: ContractId) =
+    proc onProofRequired(id: SlotId) =
       called = true
     proving.onProofRequired = onProofRequired
     proofs.setProofRequired(id, true)
@@ -93,18 +93,18 @@ suite "Proving":
     check not called
 
   test "submits proofs":
-    let id = ContractId.example
+    let id = SlotId.example
     let proof = seq[byte].example
     await proving.submitProof(id, proof)
 
   test "supports proof submission subscriptions":
-    let id = ContractId.example
+    let id = SlotId.example
     let proof = seq[byte].example
 
-    var receivedIds: seq[ContractId]
+    var receivedIds: seq[SlotId]
     var receivedProofs: seq[seq[byte]]
 
-    proc onProofSubmission(id: ContractId, proof: seq[byte]) =
+    proc onProofSubmission(id: SlotId, proof: seq[byte]) =
       receivedIds.add(id)
       receivedProofs.add(proof)
 

--- a/tests/contracts/examples.nim
+++ b/tests/contracts/examples.nim
@@ -31,5 +31,5 @@ proc example*(_: type StorageRequest): StorageRequest =
       )
     ),
     expiry: (getTime() + initDuration(hours=1)).toUnix.u256,
-    nonce: array[32, byte].example
+    nonce: Nonce.example
   )

--- a/tests/contracts/testMarket.nim
+++ b/tests/contracts/testMarket.nim
@@ -57,9 +57,9 @@ ethersuite "On-Chain Market":
     check (await market.getRequest(request.id)) == some request
 
   test "supports request subscriptions":
-    var receivedIds: seq[array[32, byte]]
+    var receivedIds: seq[RequestId]
     var receivedAsks: seq[StorageAsk]
-    proc onRequest(id: array[32, byte], ask: StorageAsk) =
+    proc onRequest(id: RequestId, ask: StorageAsk) =
       receivedIds.add(id)
       receivedAsks.add(ask)
     let subscription = await market.subscribeRequests(onRequest)
@@ -84,9 +84,9 @@ ethersuite "On-Chain Market":
   test "support slot filled subscriptions":
     await token.approve(storage.address, request.price)
     discard await market.requestStorage(request)
-    var receivedIds: seq[array[32, byte]]
+    var receivedIds: seq[RequestId]
     var receivedSlotIndices: seq[UInt256]
-    proc onSlotFilled(id: array[32, byte], slotIndex: UInt256) =
+    proc onSlotFilled(id: RequestId, slotIndex: UInt256) =
       receivedIds.add(id)
       receivedSlotIndices.add(slotIndex)
     let subscription = await market.subscribeSlotFilled(request.id, slotIndex, onSlotFilled)
@@ -100,7 +100,7 @@ ethersuite "On-Chain Market":
     await token.approve(storage.address, request.price)
     discard await market.requestStorage(request)
     var receivedSlotIndices: seq[UInt256]
-    proc onSlotFilled(requestId: array[32, byte], slotIndex: UInt256) =
+    proc onSlotFilled(requestId: RequestId, slotIndex: UInt256) =
       receivedSlotIndices.add(slotIndex)
     let subscription = await market.subscribeSlotFilled(request.id, slotIndex, onSlotFilled)
     await market.fillSlot(request.id, slotIndex - 1, proof)
@@ -112,8 +112,8 @@ ethersuite "On-Chain Market":
   test "support fulfillment subscriptions":
     await token.approve(storage.address, request.price)
     discard await market.requestStorage(request)
-    var receivedIds: seq[array[32, byte]]
-    proc onFulfillment(id: array[32, byte]) =
+    var receivedIds: seq[RequestId]
+    proc onFulfillment(id: RequestId) =
       receivedIds.add(id)
     let subscription = await market.subscribeFulfillment(request.id, onFulfillment)
     for slotIndex in 0..<request.ask.slots:
@@ -130,8 +130,8 @@ ethersuite "On-Chain Market":
     await token.approve(storage.address, otherrequest.price)
     discard await market.requestStorage(otherRequest)
 
-    var receivedIds: seq[array[32, byte]]
-    proc onFulfillment(id: array[32, byte]) =
+    var receivedIds: seq[RequestId]
+    proc onFulfillment(id: RequestId) =
       receivedIds.add(id)
 
     let subscription = await market.subscribeFulfillment(request.id, onFulfillment)

--- a/tests/contracts/testProofs.nim
+++ b/tests/contracts/testProofs.nim
@@ -5,7 +5,7 @@ import ./time
 
 ethersuite "On-Chain Proofs":
 
-  let contractId = ContractId.example
+  let contractId = SlotId.example
   let proof = seq[byte].example
 
   var proofs: OnChainProofs
@@ -34,10 +34,10 @@ ethersuite "On-Chain Proofs":
     await proofs.submitProof(contractId, proof)
 
   test "supports proof submission subscriptions":
-    var receivedIds: seq[ContractId]
+    var receivedIds: seq[SlotId]
     var receivedProofs: seq[seq[byte]]
 
-    proc onProofSubmission(id: ContractId, proof: seq[byte]) =
+    proc onProofSubmission(id: SlotId, proof: seq[byte]) =
       receivedIds.add(id)
       receivedProofs.add(proof)
 

--- a/tests/examples.nim
+++ b/tests/examples.nim
@@ -1,5 +1,6 @@
 import std/random
 import std/sequtils
+import pkg/codex/proving
 import pkg/stint
 
 proc example*[T: SomeInteger](_: type T): T =
@@ -15,3 +16,6 @@ proc example*[T](_: type seq[T]): seq[T] =
 
 proc example*(_: type UInt256): UInt256 =
   UInt256.fromBytes(array[32, byte].example)
+
+proc example*[T: RequestId | SlotId | Nonce](_: type T): T =
+  T(array[32, byte].example)


### PR DESCRIPTION
Cleaning up the variety of `array[32, byte]`'s to make the code a bit more descriptive and avoid confusion between types like `RequestId` and `SlotId`.
- rename `ContractId` to `SlotId`
- add `RequestId`, `PurchaseId`, `Nonce` types as distinct aliases of `array[32, byte]`
- rename `Proving.contracts` to `Proving.slots`
- Add/modify conversions to support the distinct type (ABI encoding/decoding, JSON encoding, REST decoding).
- Update tests 

Closes #214
Closes #184 (duplicate)

### NOTE
Updates nim-ethers dependency to PR branch https://github.com/status-im/nim-ethers/pull/31. Probably best to merge the nim-ethers PR first, then update the commit hash to point to main.