### PR TITLE
Download files without padding

### DIFF
--- a/codex/chunker.nim
+++ b/codex/chunker.nim
@@ -36,12 +36,14 @@ type
     FixedChunker
     RabinChunker
 
-  Chunker* = object
-    reader*: Reader
+  # Reader that splits input data into fixed-size chunks [or using Rabin Chunking - not supported ATM]
+  Chunker* = ref object
+    reader*: Reader               # Procedure called to actually read the data
+    offset*: int                  # Bytes read so far (position in the stream)
     case kind*: ChunkerType:
     of FixedChunker:
-      chunkSize*: Natural
-      pad*: bool # pad last block if less than size
+      chunkSize*: Natural         # Size of each chunk
+      pad*: bool                  # Pad last block to chunkSize?
     of RabinChunker:
       discard
 
@@ -58,6 +60,8 @@ proc getBytes*(c: Chunker): Future[seq[byte]] {.async.} =
 
   if read <= 0:
     return @[]
+
+  c.offset += read
 
   if not c.pad and buff.len > read:
     buff.setLen(read)

--- a/codex/chunker.nim
+++ b/codex/chunker.nim
@@ -65,8 +65,7 @@ func new*(
   chunkSize = DefaultChunkSize,
   pad = true): T =
 
-  Chunker(
-    reader: reader,
+  T(reader: reader,
     offset: 0,
     chunkSize: chunkSize,
     pad: pad)
@@ -93,7 +92,7 @@ proc new*(
 
     return res
 
-  Chunker.new(
+  T.new(
     reader = reader,
     chunkSize = chunkSize,
     pad = pad)
@@ -124,7 +123,7 @@ proc new*(
 
     return total
 
-  Chunker.new(
+  T.new(
     reader = reader,
     chunkSize = chunkSize,
     pad = pad)

--- a/codex/manifest/coders.nim
+++ b/codex/manifest/coders.nim
@@ -29,6 +29,7 @@ func encode*(_: DagPBCoder, manifest: Manifest): ?!seq[byte] =
   ## multicodec container (Dag-pb) for now
   ##
 
+  manifest.verify
   var pbNode = initProtoBuffer()
 
   for c in manifest.blocks:
@@ -160,6 +161,7 @@ func decode*(_: DagPBCoder, data: openArray[byte]): ?!Manifest =
     self.originalCid = ? Cid.init(originalCid).mapFailure
     self.originalLen = originalLen.int
 
+  self.verify
   self.success
 
 proc encode*(

--- a/codex/manifest/coders.nim
+++ b/codex/manifest/coders.nim
@@ -7,6 +7,8 @@
 ## This file may not be copied, modified, or distributed except according to
 ## those terms.
 
+# This module implements serialization and deserialization of Manifest
+
 import pkg/upraises
 
 push: {.upraises: [].}

--- a/codex/manifest/coders.nim
+++ b/codex/manifest/coders.nim
@@ -31,7 +31,7 @@ func encode*(_: DagPBCoder, manifest: Manifest): ?!seq[byte] =
   ## multicodec container (Dag-pb) for now
   ##
 
-  manifest.verify
+  ? manifest.verify()
   var pbNode = initProtoBuffer()
 
   for c in manifest.blocks:
@@ -163,7 +163,7 @@ func decode*(_: DagPBCoder, data: openArray[byte]): ?!Manifest =
     self.originalCid = ? Cid.init(originalCid).mapFailure
     self.originalLen = originalLen.int
 
-  self.verify
+  ? self.verify()
   self.success
 
 proc encode*(

--- a/codex/manifest/manifest.nim
+++ b/codex/manifest/manifest.nim
@@ -84,16 +84,18 @@ func steps*(self: Manifest): int =
   ## Number of EC groups in *protected* manifest
   divUp(self.originalLen, self.K)
 
-func verify*(self: Manifest) =
+func verify*(self: Manifest): ?!void =
   ## Check manifest correctness
   ##
   let originalLen = (if self.protected: self.originalLen else: self.len)
 
   if divUp(self.originalBytes, self.blockSize) != originalLen:
-    raise newException(Defect, "Broken manifest: wrong originalBytes")
+    return failure newException(CodexError, "Broken manifest: wrong originalBytes")
 
   if self.protected and (self.len != self.steps * (self.K + self.M)):
-    raise newException(Defect, "Broken manifest: wrong originalLen")
+    return failure newException(CodexError, "Broken manifest: wrong originalLen")
+
+  return success()
 
 
 ############################################################
@@ -210,7 +212,7 @@ proc new*(
       .catch
       .get()
 
-  self.verify
+  ? self.verify()
   self.success
 
 proc new*(

--- a/codex/manifest/manifest.nim
+++ b/codex/manifest/manifest.nim
@@ -25,8 +25,12 @@ import ./coders
 func len*(self: Manifest): int =
   self.blocks.len
 
-func size*(self: Manifest): int =
-  self.blocks.len * self.blockSize
+func originalBytesPadded*(self: Manifest): int =
+  ## Size of the original file, padded to blockSize
+  if self.protected:
+    self.originalLen * self.blockSize
+  else:
+    self.len * self.blockSize
 
 func `[]`*(self: Manifest, i: Natural): Cid =
   self.blocks[i]

--- a/codex/manifest/manifest.nim
+++ b/codex/manifest/manifest.nim
@@ -47,6 +47,7 @@ func `[]=`*(self: Manifest, i: BackwardsIndex, item: Cid) =
   self.blocks[self.len - i.int] = item
 
 proc add*(self: Manifest, cid: Cid) =
+  assert not self.protected  # we expect that protected manifests are created with properly-sized self.blocks
   self.rootHash = Cid.none
   trace "Adding cid to manifest", cid
   self.blocks.add(cid)

--- a/codex/manifest/manifest.nim
+++ b/codex/manifest/manifest.nim
@@ -25,12 +25,12 @@ import ./coders
 func len*(self: Manifest): int =
   self.blocks.len
 
-func originalBytesPadded*(self: Manifest): int =
-  ## Size of the original file, padded to blockSize
-  if self.protected:
-    self.originalLen * self.blockSize
-  else:
+func bytes*(self: Manifest, pad = true): int =
+  ## Compute how many bytes corresponding StoreStream(Manifest, pad) will return
+  if pad or self.protected:
     self.len * self.blockSize
+  else:
+    self.originalBytes
 
 func `[]`*(self: Manifest, i: Natural): Cid =
   self.blocks[i]

--- a/codex/manifest/types.nim
+++ b/codex/manifest/types.nim
@@ -26,7 +26,7 @@ const
 type
   Manifest* = ref object of RootObj
     rootHash*: ?Cid         # Root (tree) hash of the contained data set
-    originalBytes*: int     # Exact file size
+    originalBytes*: int     # Exact size of the original (uploaded) file
     blockSize*: int         # Size of each contained block (might not be needed if blocks are len-prefixed)
     blocks*: seq[Cid]       # Block Cid
     version*: CidVersion    # Cid version

--- a/codex/manifest/types.nim
+++ b/codex/manifest/types.nim
@@ -7,6 +7,8 @@
 ## This file may not be copied, modified, or distributed except according to
 ## those terms.
 
+# This module defines Manifest and all related types
+
 import std/tables
 import pkg/libp2p
 import pkg/questionable

--- a/codex/manifest/types.nim
+++ b/codex/manifest/types.nim
@@ -25,9 +25,10 @@ const
 
 type
   Manifest* = ref object of RootObj
-    rootHash*: ?Cid         # root (tree) hash of the contained data set
-    blockSize*: int         # size of each contained block (might not be needed if blocks are len-prefixed)
-    blocks*: seq[Cid]       # block Cid
+    rootHash*: ?Cid         # Root (tree) hash of the contained data set
+    originalBytes*: int     # Exact file size
+    blockSize*: int         # Size of each contained block (might not be needed if blocks are len-prefixed)
+    blocks*: seq[Cid]       # Block Cid
     version*: CidVersion    # Cid version
     hcodec*: MultiCodec     # Multihash codec
     codec*: MultiCodec      # Data set codec

--- a/codex/node.nim
+++ b/codex/node.nim
@@ -166,11 +166,11 @@ proc store*(
   stream: LPStream): Future[?!Cid] {.async.} =
   trace "Storing data"
 
-  without var blockManifest =? Manifest.new():
+  without var blockManifest =? Manifest.new(blockSize = BlockSize):
     return failure("Unable to create Block Set")
 
-  let
-    chunker = LPStreamChunker.new(stream, chunkSize = BlockSize)
+  # Manifest and chunker should have the same chunk size
+  let chunker = LPStreamChunker.new(stream, chunkSize = BlockSize)
 
   try:
     while (

--- a/codex/streams/storestream.nim
+++ b/codex/streams/storestream.nim
@@ -52,10 +52,7 @@ proc new*(
   result.initStream()
 
 method `size`*(self: StoreStream): int =
-  if self.pad:
-    self.manifest.originalBytesPadded
-  else:
-    self.manifest.originalBytes
+  bytes(self.manifest, self.pad)
 
 proc `size=`*(self: StoreStream, size: int)
   {.error: "Setting the size is forbidden".} =

--- a/codex/streams/storestream.nim
+++ b/codex/streams/storestream.nim
@@ -82,7 +82,7 @@ method readOnce*(
     let
       blockNum    = self.offset div self.manifest.blockSize
       blockOffset = self.offset mod self.manifest.blockSize
-      readBytes   = min([nbytes - read, self.manifest.blockSize - blockOffset, self.size - self.offset])
+      readBytes   = min([self.size - self.offset, nbytes - read, self.manifest.blockSize - blockOffset])
 
     # Read contents of block `blockNum`
     without blk =? await self.store.getBlock(self.manifest[blockNum]), error:

--- a/codex/utils.nim
+++ b/codex/utils.nim
@@ -2,3 +2,14 @@ import ./utils/asyncheapqueue
 import ./utils/fileutils
 
 export asyncheapqueue, fileutils
+
+
+func divUp*[T](a, b : T): T =
+  ## Division with result rounded up (rather than truncated as in 'div')
+  assert(b != 0)
+  if a==0:  0  else:  ((a - 1) div b) + 1
+
+func roundUp*[T](a, b : T): T =
+  ## Round up 'a' to the next value divisible by 'b'
+  divUp(a,b) * b
+

--- a/tests/codex/helpers/randomchunker.nim
+++ b/tests/codex/helpers/randomchunker.nim
@@ -13,7 +13,6 @@ type
 proc new*(
   T: type RandomChunker,
   rng: Rng,
-  kind = ChunkerType.FixedChunker,
   chunkSize = DefaultChunkSize,
   size: int,
   pad = false): T =
@@ -43,7 +42,6 @@ proc new*(
     return read
 
   Chunker.new(
-    kind = ChunkerType.FixedChunker,
     reader = reader,
     pad = pad,
     chunkSize = chunkSize)

--- a/tests/codex/testnode.nim
+++ b/tests/codex/testnode.nim
@@ -179,6 +179,9 @@ suite "Test Node":
       (await localStore.putBlock(blk)).tryGet()
       manifest.add(blk.cid)
 
+    manifest.originalBytes = chunker.offset  # store the exact file size
+    original.setLen(manifest.originalBytes)
+
     let
       manifestBlock = bt.Block.new(
           manifest.encode().tryGet(),


### PR DESCRIPTION
Note that the wire format of Manifest was changed, so we need to recreate all BlockStores.

Closes #98.