### PR TITLE
Fixed message.proto to match IPFS specs

### DIFF
--- a/codex/blockexchange/protobuf/message.proto
+++ b/codex/blockexchange/protobuf/message.proto
@@ -47,9 +47,9 @@ message Message {
   }
 
   Wantlist wantlist = 1;
-  repeated Block payload = 2;
-  repeated BlockPresence blockPresences = 3;
-  int32 pendingBytes = 4;
-  AccountMessage account = 5;
-  StateChannelUpdate payment = 6;
+  repeated Block payload = 3;
+  repeated BlockPresence blockPresences = 4;
+  int32 pendingBytes = 5;
+  AccountMessage account = 6;
+  StateChannelUpdate payment = 7;
 }


### PR DESCRIPTION
We incorrectly assigned code 2 to the payload field instead of code 3:

Our code: https://github.com/status-im/nim-codex/blob/8c5939252607f74b60a49fee4570734ffa06b11c/codex/blockexchange/protobuf/message.proto#L50-L52

While original code: https://github.com/ipfs/go-bitswap/blob/0fa397581ca6197c6c4ca17842719370f6596e95/message/pb/message.proto#L43-L45

And [documentation](https://github.com/ipfs/specs/blob/main/BITSWAP.md#bitswap-120-wire-format).