### PR TITLE
Add a run-time start-up switch -s/--store-backend to choose the data store backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The following options are available:
      --metrics-address      Listening address of the metrics server [=127.0.0.1].
      --metrics-port         Listening HTTP port of the metrics server [=8008].
  -d, --data-dir             The directory where codex will store configuration and data..
- -s, --store-backend        The data store backend [=StoreKind.FS].
+ -s, --store-backend        data store backend: fs, sqlite [=fs].
  -l, --listen-port          Specifies one or more listening ports for the node to listen on. [=0].
  -i, --listen-ip            The public IP [=0.0.0.0].
      --udp-port             Specify the discovery (UDP) port [=8090].

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The following options are available:
      --metrics-address      Listening address of the metrics server [=127.0.0.1].
      --metrics-port         Listening HTTP port of the metrics server [=8008].
  -d, --data-dir             The directory where codex will store configuration and data..
+ -s, --store-backend        The data store backend [=StoreKind.FS].
  -l, --listen-port          Specifies one or more listening ports for the node to listen on. [=0].
  -i, --listen-ip            The public IP [=0.0.0.0].
      --udp-port             Specify the discovery (UDP) port [=8090].

--- a/codex/codex.nim
+++ b/codex/codex.nim
@@ -140,8 +140,15 @@ proc new*(T: type CodexServer, config: CodexConf): T =
     raise (ref Defect)(
       msg: "Unable to create data directory for block store: " & repoDir)
 
+  let localStore =
+    case config.storeBackend
+    of FS:
+      notice "Using FS backend data store"
+      FSStore.new(repoDir, cache = cache)
+    of SQLite:
+      notice "Using SQLite backend data store"
+      SQLiteStore.new(repoDir, cache = cache)
   let
-    localStore = SQLiteStore.new(repoDir, cache = cache)
     peerStore = PeerCtxStore.new()
     pendingBlocks = PendingBlocksManager.new()
     discovery = DiscoveryEngine.new(localStore, peerStore, network, blockDiscovery, pendingBlocks)

--- a/codex/codex.nim
+++ b/codex/codex.nim
@@ -142,6 +142,9 @@ proc new*(T: type CodexServer, config: CodexConf): T =
 
   let localStore =
     case config.storeBackend
+    of cachedStore:
+      notice "Using --cache backend data store"
+      cache
     of FS:
       notice "Using FS backend data store"
       FSStore.new(repoDir, cache = cache)

--- a/codex/conf.nim
+++ b/codex/conf.nim
@@ -86,8 +86,9 @@ type
       name: "data-dir" }: OutDir
 
     storeBackend* {.
-      desc: "The data store backend"
+      desc: "data store backend: fs, sqlite"
       defaultValue: StoreKind.FS
+      defaultValueDesc: "fs"
       abbr: "s"
       name: "store-backend"
     .}: StoreKind

--- a/codex/conf.nim
+++ b/codex/conf.nim
@@ -44,6 +44,10 @@ type
     Json = "json"
     None = "none"
 
+  StoreKind* = enum
+    FS = "fs"
+    SQLite = "sqlite"
+
   CodexConf* = object
     logLevel* {.
       defaultValue: LogLevel.INFO
@@ -79,6 +83,13 @@ type
       defaultValueDesc: ""
       abbr: "d"
       name: "data-dir" }: OutDir
+
+    storeBackend* {.
+      desc: "The data store backend"
+      defaultValue: StoreKind.FS
+      abbr: "s"
+      name: "store-backend"
+    .}: StoreKind
 
     case cmd* {.
       command

--- a/codex/conf.nim
+++ b/codex/conf.nim
@@ -45,6 +45,7 @@ type
     None = "none"
 
   StoreKind* = enum
+    cachedStore = "cached"
     FS = "fs"
     SQLite = "sqlite"
 


### PR DESCRIPTION
With current default chunk sizes, a `d:release` build & big upload, SQLite uses 20% more space & 30% more time than files on a Linux tmpfs/Intel.  So, SQLite may not be the hoped for performance win (and there may be other workloads where the perf delta is much worse).

More generally, different host devices/FSes will always have different ideal back-ends.  So, some kind of choice makes baseline sense. (Indeed, any user choice raises the idea of a translation engine to re-format a repo (FS <-> SQLite) when re-hosting to a new device, but that is unlikely to be a near term concern.)

If the idea of a DataStore is switching backends behind its abstraction, this also lets us exercise said switchability.  It also lets us more easily test any "above DataStore" quota abstraction -- e.g., some generic [pre-space-allocating solution](https://github.com/status-im/nim-codex/issues/159#issuecomment-1245141769) with multiple backends.

(I realize this needs some hook into our testing framework which I am still figuring out, but I wanted to start the PR for any design feedback.)

EDIT: Related https://github.com/status-im/nim-codex/issues/179 and https://github.com/status-im/nim-codex/pull/160#pullrequestreview-1057936220