### PR TITLE
Rework Purchase as a state machine

### DIFF
--- a/codex/purchasing/purchase.nim
+++ b/codex/purchasing/purchase.nim
@@ -1,0 +1,58 @@
+import ../market
+import ../clock
+import ./purchaseid
+
+export purchaseid
+
+type
+  Purchase* = ref object
+    future: Future[void]
+    market: Market
+    clock: Clock
+    request*: StorageRequest
+
+func newPurchase*(request: StorageRequest,
+                  market: Market,
+                  clock: Clock): Purchase =
+  Purchase(request: request, market: market, clock: clock)
+
+proc run(purchase: Purchase) {.async.} =
+  let market = purchase.market
+  let clock = purchase.clock
+
+  proc requestStorage {.async.} =
+    purchase.request = await market.requestStorage(purchase.request)
+
+  proc waitUntilFulfilled {.async.} =
+    let done = newFuture[void]()
+    proc callback(_: RequestId) =
+      done.complete()
+    let request = purchase.request
+    let subscription = await market.subscribeFulfillment(request.id, callback)
+    await done
+    await subscription.unsubscribe()
+
+  proc withTimeout(future: Future[void]) {.async.} =
+    let expiry = purchase.request.expiry.truncate(int64)
+    await future.withTimeout(clock, expiry)
+
+  await requestStorage()
+  await waitUntilFulfilled().withTimeout()
+
+proc start*(purchase: Purchase) =
+  purchase.future = purchase.run()
+
+proc wait*(purchase: Purchase) {.async.} =
+  await purchase.future
+
+func id*(purchase: Purchase): PurchaseId =
+  PurchaseId(purchase.request.id)
+
+func finished*(purchase: Purchase): bool =
+  purchase.future.finished
+
+func error*(purchase: Purchase): ?(ref CatchableError) =
+  if purchase.future.failed:
+    some purchase.future.error
+  else:
+    none (ref CatchableError)

--- a/codex/purchasing/purchaseid.nim
+++ b/codex/purchasing/purchaseid.nim
@@ -1,0 +1,8 @@
+import std/hashes
+import pkg/nimcrypto
+
+type PurchaseId* = distinct array[32, byte]
+
+proc hash*(x: PurchaseId): Hash {.borrow.}
+proc `==`*(x, y: PurchaseId): bool {.borrow.}
+proc toHex*(x: PurchaseId): string = array[32, byte](x).toHex

--- a/codex/purchasing/statemachine.nim
+++ b/codex/purchasing/statemachine.nim
@@ -1,0 +1,15 @@
+import ../utils/statemachine
+import ../market
+import ../clock
+
+export market
+export clock
+export statemachine
+
+type
+  Purchase* = ref object of StateMachine
+    future*: Future[void]
+    market*: Market
+    clock*: Clock
+    request*: StorageRequest
+  PurchaseState* = ref object of AsyncState

--- a/codex/purchasing/states/cancelled.nim
+++ b/codex/purchasing/states/cancelled.nim
@@ -1,0 +1,17 @@
+import ../statemachine
+import ./error
+
+type PurchaseCancelled* = ref object of PurchaseState
+
+method enterAsync*(state: PurchaseCancelled) {.async.} =
+  without purchase =? (state.context as Purchase):
+    raiseAssert "invalid state"
+
+  try:
+    await purchase.market.withdrawFunds(purchase.request.id)
+  except CatchableError as error:
+    state.switch(PurchaseError(error: error))
+    return
+
+  let error = newException(Timeout, "Purchase cancelled due to timeout")
+  state.switch(PurchaseError(error: error))

--- a/codex/purchasing/states/error.nim
+++ b/codex/purchasing/states/error.nim
@@ -1,0 +1,10 @@
+import ../statemachine
+
+type PurchaseError* = ref object of PurchaseState
+  error*: ref CatchableError
+
+method enter*(state: PurchaseError) =
+  without purchase =? (state.context as Purchase):
+    raiseAssert "invalid state"
+
+  purchase.future.fail(state.error)

--- a/codex/purchasing/states/pending.nim
+++ b/codex/purchasing/states/pending.nim
@@ -1,0 +1,17 @@
+import ../statemachine
+import ./submitted
+import ./error
+
+type PurchasePending* = ref object of PurchaseState
+
+method enterAsync(state: PurchasePending) {.async.} =
+  without purchase =? (state.context as Purchase):
+    raiseAssert "invalid state"
+
+  try:
+    purchase.request = await purchase.market.requestStorage(purchase.request)
+  except CatchableError as error:
+    state.switch(PurchaseError(error: error))
+    return
+
+  state.switch(PurchaseSubmitted())

--- a/codex/purchasing/states/started.nim
+++ b/codex/purchasing/states/started.nim
@@ -1,0 +1,9 @@
+import ../statemachine
+
+type PurchaseStarted* = ref object of PurchaseState
+
+method enter*(state: PurchaseStarted) =
+  without purchase =? (state.context as Purchase):
+    raiseAssert "invalid state"
+
+  purchase.future.complete()

--- a/codex/purchasing/states/submitted.nim
+++ b/codex/purchasing/states/submitted.nim
@@ -1,0 +1,37 @@
+import ../statemachine
+import ./error
+import ./started
+import ./cancelled
+
+type PurchaseSubmitted* = ref object of PurchaseState
+
+method enterAsync(state: PurchaseSubmitted) {.async.} =
+  without purchase =? (state.context as Purchase):
+    raiseAssert "invalid state"
+
+  let market = purchase.market
+  let clock = purchase.clock
+
+  proc wait {.async.} =
+    let done = newFuture[void]()
+    proc callback(_: RequestId) =
+      done.complete()
+    let request = purchase.request
+    let subscription = await market.subscribeFulfillment(request.id, callback)
+    await done
+    await subscription.unsubscribe()
+
+  proc withTimeout(future: Future[void]) {.async.} =
+    let expiry = purchase.request.expiry.truncate(int64)
+    await future.withTimeout(clock, expiry)
+
+  try:
+    await wait().withTimeout()
+  except Timeout:
+    state.switch(PurchaseCancelled())
+    return
+  except CatchableError as error:
+    state.switch(PurchaseError(error: error))
+    return
+
+  state.switch(PurchaseStarted())

--- a/codex/utils/optionalcast.nim
+++ b/codex/utils/optionalcast.nim
@@ -1,0 +1,16 @@
+import pkg/questionable
+import pkg/questionable/operators
+
+export questionable
+
+proc `as`*[T](value: T, U: type): ?U =
+  ## Casts a value to another type, returns an Option.
+  ## When the cast succeeds, the option will contain the casted value.
+  ## When the cast fails, the option will have no value.
+  when value is U:
+    return some value
+  elif value is ref object:
+    if value of U:
+      return some U(value)
+
+Option.liftBinary `as`

--- a/codex/utils/statemachine.nim
+++ b/codex/utils/statemachine.nim
@@ -1,0 +1,86 @@
+import pkg/questionable
+import ./optionalcast
+
+## Implementation of the the state pattern:
+## https://en.wikipedia.org/wiki/State_pattern
+##
+## Define your own state machine and state types:
+##
+##     type
+##       Light = ref object of StateMachine
+##         color: string
+##       LightState = ref object of State
+##
+##     let light = Light(color: "yellow")
+##
+## Define the states:
+##
+##     type
+##       On = ref object of LightState
+##       Off = ref object of LightState
+##
+## Perform actions on state entry and exit:
+##
+##     method enter(state: On) =
+##       echo light.color, " light switched on"
+##
+##     method exit(state: On) =
+##       echo light.color, " light no longer switched on"
+##
+##     light.switch(On())  # prints: 'light switched on'
+##     light.switch(Off()) # prints: 'light no longer switched on'
+##
+##  Allow behaviour to change based on the current state:
+##
+##     method description*(state: LightState): string {.base.} =
+##       return "a light"
+##
+##     method description*(state: On): string =
+##       if light =? (state.context as Light):
+##         return "a " & light.color & " light"
+##
+##     method description*(state: Off): string =
+##       return "a dark light"
+##
+##     proc description*(light: Light): string =
+##       if state =? (light.state as LightState):
+##         return state.description
+##
+##     light.switch(On())
+##     echo light.description # prints: 'a yellow light'
+##     light.switch(Off())
+##     echo light.description # prints 'a dark light'
+
+
+export questionable
+export optionalcast
+
+type
+  StateMachine* = ref object of RootObj
+    state: ?State
+  State* = ref object of RootObj
+    context: ?StateMachine
+
+method enter(state: State) {.base.} =
+  discard
+
+method exit(state: State) {.base.} =
+  discard
+
+func state*(machine: StateMachine): ?State =
+  machine.state
+
+func context*(state: State): ?StateMachine =
+  state.context
+
+proc switch*(machine: StateMachine, newState: State) =
+  if state =? machine.state:
+    state.exit()
+    state.context = StateMachine.none
+  machine.state = newState.some
+  newState.context = machine.some
+  newState.enter()
+
+proc switch*(oldState, newState: State) =
+  if context =? oldState.context:
+    context.switch(newState)

--- a/codex/utils/statemachine.nim
+++ b/codex/utils/statemachine.nim
@@ -1,4 +1,5 @@
 import pkg/questionable
+import pkg/chronos
 import ./optionalcast
 
 ## Implementation of the the state pattern:
@@ -84,3 +85,18 @@ proc switch*(machine: StateMachine, newState: State) =
 proc switch*(oldState, newState: State) =
   if context =? oldState.context:
     context.switch(newState)
+
+type
+  AsyncState* = ref object of State
+
+method enterAsync(state: AsyncState) {.base, async.} =
+  discard
+
+method exitAsync(state: AsyncState) {.base, async.} =
+  discard
+
+method enter(state: AsyncState) =
+  asyncSpawn state.enterAsync()
+
+method exit(state: AsyncState) =
+  asyncSpawn state.exitAsync()

--- a/tests/codex/testutils.nim
+++ b/tests/codex/testutils.nim
@@ -1,3 +1,4 @@
+import ./utils/teststatemachine
 import ./utils/testoptionalcast
 
 {.warning[UnusedImport]: off.}

--- a/tests/codex/testutils.nim
+++ b/tests/codex/testutils.nim
@@ -1,0 +1,3 @@
+import ./utils/testoptionalcast
+
+{.warning[UnusedImport]: off.}

--- a/tests/codex/utils/testoptionalcast.nim
+++ b/tests/codex/utils/testoptionalcast.nim
@@ -1,0 +1,30 @@
+import std/unittest
+import codex/utils/optionalcast
+
+suite "optional casts":
+
+  test "casting value to same type works":
+    check 42 as int == some 42
+
+  test "casting value to unrelated type evaluates to None":
+    check 42 as string == string.none
+
+  test "casting value to subtype works":
+    type
+      BaseType = ref object of RootObj
+      SubType = ref object of BaseType
+    let x: BaseType = SubType()
+    check x as SubType == SubType(x).some
+
+  test "casting to unrelated subtype evaluates to None":
+    type
+      BaseType = ref object of RootObj
+      SubType = ref object of BaseType
+      OtherType = ref object of BaseType
+    let x: BaseType = SubType()
+    check x as OtherType == OtherType.none
+
+  test "casting works on optional types":
+    check 42.some as int == some 42
+    check 42.some as string == string.none
+    check int.none as int == int.none

--- a/tests/codex/utils/teststatemachine.nim
+++ b/tests/codex/utils/teststatemachine.nim
@@ -1,0 +1,48 @@
+import std/unittest
+import pkg/questionable
+import codex/utils/statemachine
+
+type
+  Light = ref object of StateMachine
+  On = ref object of State
+  Off = ref object of State
+
+var enteredOn: bool
+var exitedOn: bool
+
+method enter(state: On) =
+  enteredOn = true
+
+method exit(state: On) =
+  exitedOn = true
+
+suite "state machines":
+
+  setup:
+    enteredOn = false
+    exitedOn = false
+
+  test "calls `enter` when entering state":
+    Light().switch(On())
+    check enteredOn
+
+  test "calls `exit` when exiting state":
+    let light = Light()
+    light.switch(On())
+    check not exitedOn
+    light.switch(Off())
+    check exitedOn
+
+  test "allows access to state machine from state":
+    let light = Light()
+    let on = On()
+    check not isSome on.context
+    light.switch(on)
+    check on.context == some StateMachine(light)
+
+  test "removes access to state machine when state exited":
+    let light = Light()
+    let on = On()
+    light.switch(on)
+    light.switch(Off())
+    check not isSome on.context

--- a/tests/testCodex.nim
+++ b/tests/testCodex.nim
@@ -10,6 +10,7 @@ import ./codex/testpurchasing
 import ./codex/testsales
 import ./codex/testerasure
 import ./codex/testproving
+import ./codex/testutils
 
 # to check that everything compiles
 import ../codex


### PR DESCRIPTION
A Purchase already underwent several stages before it was completed. This refactor makes the states that a purchase goes through explicit using a state pattern.

This is part of the work to ensure that purchases survive a restart of the node.