### PR TITLE
WIP: fix crash when can't find a CID and timeout hits

### DIFF
--- a/codex/blockexchange/engine/pendingblocks.nim
+++ b/codex/blockexchange/engine/pendingblocks.nim
@@ -48,6 +48,8 @@ proc getWantHandle*(
     raise exc
   except CatchableError as exc:
     trace "Pending WANT failed or expired", exc = exc.msg
+    # no need to cancel, it is already cancelled by wait()
+    raise exc
   finally:
     p.blocks.del(cid)
 


### PR DESCRIPTION
This is to fix a crash if a CID is not found (after 10 minutes default)

WIP as it still needs tests.

Signed-off-by: Csaba Kiraly <csaba.kiraly@gmail.com>