### PR TITLE
setup and persist private key

### DIFF
--- a/codex.nim
+++ b/codex.nim
@@ -35,6 +35,10 @@ when isMainModule:
   config.setupLogging()
   config.setupMetrics()
 
+  if config.nat.isNone and config.discoveryIp.isNone:
+    error "Either `disc-ip` or `nat` or both arguments are needed!"
+    quit QuitFailure
+
   case config.cmd:
   of StartUpCommand.noCommand:
 

--- a/codex.nim
+++ b/codex.nim
@@ -14,14 +14,13 @@ import pkg/libp2p
 
 import ./codex/conf
 import ./codex/codex
+import ./codex/utils/keyutils
 
 export codex, conf, libp2p, chronos, chronicles
 
 when isMainModule:
   import std/os
-
   import pkg/confutils/defs
-
   import ./codex/utils/fileutils
 
   logScope:
@@ -53,7 +52,15 @@ when isMainModule:
 
     trace "Repo dir initialized", dir = config.dataDir / "repo"
 
-    let server = CodexServer.new(config)
+    let
+      keyPath =
+        if isAbsolute(string config.netPrivKeyFile):
+          string config.netPrivKeyFile
+        else:
+          string config.dataDir / string config.netPrivKeyFile
+
+      privateKey = setupKey(keyPath).expect("Should setup private key!")
+      server = CodexServer.new(config, privateKey)
 
     ## Ctrl+C handling
     proc controlCHandler() {.noconv.} =

--- a/codex.nim
+++ b/codex.nim
@@ -35,12 +35,15 @@ when isMainModule:
   config.setupLogging()
   config.setupMetrics()
 
-  if config.nat.isNone and config.discoveryIp.isNone:
-    error "Either `disc-ip` or `nat` or both arguments are needed!"
-    quit QuitFailure
-
   case config.cmd:
   of StartUpCommand.noCommand:
+
+    if config.nat == ValidIpAddress.init(IPv4_any()):
+      error "`--nat` cannot be set to the any (`0.0.0.0`) address"
+      quit QuitFailure
+
+    if config.nat == ValidIpAddress.init("127.0.0.1"):
+      warn "`--nat` is set to local loopback, your node wont be properly announce over the DHT"
 
     if not(checkAndCreateDataDir((config.dataDir).string)):
       # We are unable to access/create data folder or data folder's

--- a/codex/codex.nim
+++ b/codex/codex.nim
@@ -34,6 +34,9 @@ import ./contracts
 import ./utils/keyutils
 import ./utils/addrutils
 
+logScope:
+  topics = "codex node"
+
 type
   CodexServer* = ref object
     runHandle: Future[void]

--- a/codex/codex.nim
+++ b/codex/codex.nim
@@ -54,10 +54,10 @@ proc start*(s: CodexServer) {.async.} =
     # TODO: Can't define this as constants, pity
     natIpPart = MultiAddress.init("/ip4/" & $s.config.nat & "/")
       .expect("Should create multiaddress")
-    anyAddrIp = MultiAddress.init("/ip4/0.0.0.0/").
-      expect("Should create multiaddress")
-    loopBackAddrIp = MultiAddress.init("/ip4/127.0.0.1/").
-      expect("Should create multiaddress")
+    anyAddrIp = MultiAddress.init("/ip4/0.0.0.0/")
+      .expect("Should create multiaddress")
+    loopBackAddrIp = MultiAddress.init("/ip4/127.0.0.1/")
+      .expect("Should create multiaddress")
 
     # announce addresses should be set to bound addresses,
     # but the IP should be mapped to the provided nat ip

--- a/codex/codex.nim
+++ b/codex/codex.nim
@@ -159,7 +159,7 @@ proc new*(T: type CodexServer, config: CodexConf, privateKey: CodexPrivateKey): 
     store = NetworkStore.new(engine, localStore)
     erasure = Erasure.new(store, leoEncoderProvider, leoDecoderProvider)
     contracts = ContractInteractions.new(config)
-    codexNode = CodexNodeRef.new(switch, store, engine, erasure, discovery, contracts, config)
+    codexNode = CodexNodeRef.new(switch, store, engine, erasure, discovery, contracts)
     restServer = RestServerRef.new(
       codexNode.initRestApi(config),
       initTAddress("127.0.0.1" , config.apiPort),

--- a/codex/codex.nim
+++ b/codex/codex.nim
@@ -126,24 +126,10 @@ proc new*(T: type CodexServer, config: CodexConf, privateKey: CodexPrivateKey): 
       config.dataDir / "dht")
       .expect("Should not fail!"))
 
-    announceAddrs =
-      if config.nat.isSome:
-        # Remap addresses with the correct announce/nat ip
-        config.listenAddrs.mapIt:
-          it.remapAddr(config.nat)
-      else:
-        config.listenAddrs
-
-    discoveryIp =
-      if config.discoveryIp.isNone:
-        config.nat.get
-      else:
-        config.discoveryIp.get
-
     discovery = Discovery.new(
       switch.peerInfo.privateKey,
-      announceAddrs = announceAddrs,
-      bindIp = discoveryIp,
+      announceAddrs = config.listenAddrs,
+      bindIp = config.discoveryIp,
       bindPort = config.discoveryPort,
       bootstrapNodes = config.bootstrapNodes,
       store = discoveryStore)

--- a/codex/conf.nim
+++ b/codex/conf.nim
@@ -109,8 +109,8 @@ type
         name: "udp-port" }: Port
 
       netPrivKeyFile* {.
-        desc: "Source of network (secp256k1) private key file (random|<path>)"
-        defaultValue: "random"
+        desc: "Source of network (secp256k1) private key file path or name"
+        defaultValue: "key"
         name: "net-privkey" }: string
 
       bootstrapNodes* {.

--- a/codex/conf.nim
+++ b/codex/conf.nim
@@ -98,14 +98,16 @@ type
       nat* {.
         # TODO: change this once we integrate nat support
         desc: "IP Addresses to announce behind a NAT"
+        defaultValue: ValidIpAddress.init("127.0.0.1")
         defaultValueDesc: "127.0.0.1"
         abbr: "a"
-        name: "nat" }: Option[ValidIpAddress]
+        name: "nat" }: ValidIpAddress
 
       discoveryIp* {.
         desc: "Discovery listen address"
+        defaultValue: ValidIpAddress.init(IPv4_any())
         defaultValueDesc: "0.0.0.0"
-        name: "disc-ip" }: Option[ValidIpAddress]
+        name: "disc-ip" }: ValidIpAddress
 
       discoveryPort* {.
         desc: "Discovery (UDP) port"

--- a/codex/conf.nim
+++ b/codex/conf.nim
@@ -95,18 +95,23 @@ type
         abbr: "i"
         name: "listen-addrs" }: seq[MultiAddress]
 
-      announceAddrs* {.
-        desc: "Multi Addresses to announce behind a NAT"
-        defaultValue: @[]
-        defaultValueDesc: ""
+      nat* {.
+        # TODO: change this once we integrate nat support
+        desc: "IP Addresses to announce behind a NAT"
+        defaultValueDesc: "127.0.0.1"
         abbr: "a"
-        name: "announce-addrs" }: seq[MultiAddress]
+        name: "nat" }: Option[ValidIpAddress]
+
+      discoveryIp* {.
+        desc: "Discovery listen address"
+        defaultValueDesc: "0.0.0.0"
+        name: "disc-ip" }: Option[ValidIpAddress]
 
       discoveryPort* {.
-        desc: "Specify the discovery (UDP) port"
+        desc: "Discovery (UDP) port"
         defaultValue: Port(8090)
         defaultValueDesc: "8090"
-        name: "udp-port" }: Port
+        name: "disc-port" }: Port
 
       netPrivKeyFile* {.
         desc: "Source of network (secp256k1) private key file path or name"
@@ -182,7 +187,6 @@ const
   codexFullVersion* =
     "Codex build " & codexVersion & "\p" &
     nimBanner
-
 
 proc defaultDataDir*(): string =
   let dataDir = when defined(windows):

--- a/codex/discovery.nim
+++ b/codex/discovery.nim
@@ -29,6 +29,9 @@ export discv5
 # deprecated, this could have been implemented
 # much more elegantly.
 
+logScope:
+  topics = "codex discovery"
+
 type
   Discovery* = ref object of RootObj
     protocol: discv5.Protocol           # dht protocol
@@ -179,7 +182,6 @@ proc new*(
       peerId: PeerId.init(key).expect("Should construct PeerId"))
 
   self.updateAnnounceRecord(announceAddrs)
-  self.updateDhtRecord(bindIp, bindPort)
 
   self.protocol = newProtocol(
     key,

--- a/codex/discovery.nim
+++ b/codex/discovery.nim
@@ -22,7 +22,6 @@ import pkg/libp2pdht/discv5/protocol as discv5
 
 import ./rng
 import ./errors
-import ./formats
 
 export discv5
 

--- a/codex/discovery.nim
+++ b/codex/discovery.nim
@@ -32,10 +32,13 @@ export discv5
 
 type
   Discovery* = ref object of RootObj
-    protocol: discv5.Protocol
-    key: PrivateKey
-    announceAddrs: seq[MultiAddress]
-    record: SignedPeerRecord
+    protocol: discv5.Protocol           # dht protocol
+    key: PrivateKey                     # private key
+    peerId: PeerId                      # the peer id of the local node
+    announceAddrs: seq[MultiAddress]    # addresses announced as part of the provider records
+    providerRecord*: ?SignedPeerRecord  # record to advertice node connection information, this carry any
+                                        # address that the node can be connected on
+    dhtRecord*: ?SignedPeerRecord       # record to advertice DHT connection information
 
 proc toNodeId*(cid: Cid): NodeId =
   ## Cid to discovery id
@@ -57,9 +60,9 @@ proc findPeer*(
 
   return
     if node.isSome():
-      some(node.get().record.data)
+      node.get().record.data.some
     else:
-      none(PeerRecord)
+      PeerRecord.none
 
 method find*(
   d: Discovery,
@@ -81,7 +84,7 @@ method provide*(d: Discovery, cid: Cid) {.async, base.} =
   trace "Providing block", cid
   let
     nodes = await d.protocol.addProvider(
-      cid.toNodeId(), d.record)
+      cid.toNodeId(), d.providerRecord.get)
 
   if nodes.len <= 0:
     trace "Couldn't provide to any nodes!"
@@ -116,7 +119,7 @@ method provide*(d: Discovery, host: ca.Address) {.async, base.} =
   trace "Providing host", host = $host
   let
     nodes = await d.protocol.addProvider(
-    host.toNodeId(), d.record)
+      host.toNodeId(), d.providerRecord.get)
   if nodes.len > 0:
     trace "Provided to nodes", nodes = nodes.len
 
@@ -127,20 +130,32 @@ method removeProvider*(d: Discovery, peerId: PeerId): Future[void] {.base.} =
   trace "Removing provider", peerId
   d.protocol.removeProvidersLocal(peerId)
 
-proc updateRecord*(d: Discovery, addrs: openArray[MultiAddress]) =
+proc updateAnnounceRecord*(d: Discovery, addrs: openArray[MultiAddress]) =
   ## Update providers record
   ##
 
   d.announceAddrs = @addrs
-  d.record = SignedPeerRecord.init(
-    d.key,
-    PeerRecord.init(
-      PeerId.init(d.key).expect("Should construct PeerId"),
-      d.announceAddrs)).expect("Should construct signed record")
+
+  trace "Updating announce record", addrs = d.announceAddrs
+  d.providerRecord = SignedPeerRecord.init(
+    d.key, PeerRecord.init(d.peerId, d.announceAddrs))
+      .expect("Should construct signed record").some
 
   if not d.protocol.isNil:
-    d.protocol.updateRecord(d.record.some)
-      .expect("should update SPR")
+    d.protocol.updateRecord(d.providerRecord)
+      .expect("Should update SPR")
+
+proc updateDhtRecord*(d: Discovery, ip: ValidIpAddress, port: Port) =
+  ## Update providers record
+  ##
+
+  trace "Updating Dht record", ip, port = $port
+  d.dhtRecord = SignedPeerRecord.init(
+    d.key, PeerRecord.init(d.peerId, @[
+      MultiAddress.init(
+        ip,
+        IpTransportProtocol.udpProtocol,
+        port)])).expect("Should construct signed record").some
 
 proc start*(d: Discovery) {.async.} =
   d.protocol.open()
@@ -152,34 +167,26 @@ proc stop*(d: Discovery) {.async.} =
 proc new*(
   T: type Discovery,
   key: PrivateKey,
-  discoveryIp = IPv4_any(),
-  discoveryPort = 0.Port,
-  announceAddrs: openArray[MultiAddress] = [],
+  bindIp = ValidIpAddress.init(IPv4_any()),
+  bindPort = 0.Port,
+  announceAddrs: openArray[MultiAddress],
   bootstrapNodes: openArray[SignedPeerRecord] = [],
   store: Datastore = SQLiteDatastore.new(Memory)
-  .expect("Should not fail!")): T =
-
-  let
-    announceAddrs =
-      if announceAddrs.len <= 0:
-        @[
-          MultiAddress.init(
-            ValidIpAddress.init(discoveryIp),
-            IpTransportProtocol.tcpProtocol,
-            discoveryPort)]
-      else:
-        @announceAddrs
+    .expect("Should not fail!")): T =
 
   var
-    self = T(key: key)
+    self = T(
+      key: key,
+      peerId: PeerId.init(key).expect("Should construct PeerId"))
 
-  self.updateRecord(announceAddrs)
+  self.updateAnnounceRecord(announceAddrs)
+  self.updateDhtRecord(bindIp, bindPort)
 
   self.protocol = newProtocol(
     key,
-    bindIp = discoveryIp,
-    bindPort = discoveryPort,
-    record = self.record,
+    bindIp = bindIp.toNormalIp,
+    bindPort = bindPort,
+    record = self.providerRecord.get,
     bootstrapRecords = bootstrapNodes,
     rng = Rng.instance(),
     providers = ProvidersManager.new(store))

--- a/codex/rest/api.nim
+++ b/codex/rest/api.nim
@@ -195,9 +195,9 @@ proc initRestApi*(node: CodexNodeRef, conf: CodexConf): RestRouter =
     "/api/codex/v1/storage/request/{cid}") do (cid: Cid) -> RestApiResponse:
       ## Create a request for storage
       ##
-      ## cid            - the cid of a previously uploaded dataset
-      ## duration       - the duration of the contract
-      ## reward       - the maximum price the client is willing to pay
+      ## cid      - the cid of a previously uploaded dataset
+      ## duration - the duration of the contract
+      ## reward   - the maximum price the client is willing to pay
 
       without cid =? cid.tryGet.catch, error:
         return RestApiResponse.error(Http400, error.msg)

--- a/codex/rest/api.nim
+++ b/codex/rest/api.nim
@@ -265,12 +265,17 @@ proc initRestApi*(node: CodexNodeRef, conf: CodexConf): RestRouter =
       ## Print rudimentary node information
       ##
 
-      let json = %*{
-        "id": $node.switch.peerInfo.peerId,
-        "addrs": node.switch.peerInfo.addrs.mapIt( $it ),
-        "repo": $conf.dataDir,
-        "spr": node.switch.peerInfo.signedPeerRecord.toURI
-      }
+      let
+        json = %*{
+          "id": $node.switch.peerInfo.peerId,
+          "addrs": node.switch.peerInfo.addrs.mapIt( $it ),
+          "repo": $conf.dataDir,
+          "spr":
+            if node.discovery.dhtRecord.isSome:
+              node.discovery.dhtRecord.get.toURI
+            else:
+              ""
+        }
 
       return RestApiResponse.response($json)
 

--- a/codex/utils/addrutils.nim
+++ b/codex/utils/addrutils.nim
@@ -1,0 +1,41 @@
+## Nim-Codex
+## Copyright (c) 2022 Status Research & Development GmbH
+## Licensed under either of
+##  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+##  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+## at your option.
+## This file may not be copied, modified, or distributed except according to
+## those terms.
+
+import pkg/upraises
+push: {.upraises: [].}
+
+import std/sequtils
+import std/strutils
+import std/options
+
+import pkg/libp2p
+import pkg/stew/shims/net
+
+func remapAddr*(
+  address: MultiAddress,
+  ip: Option[ValidIpAddress] = ValidIpAddress.none,
+  port: Option[Port] = Port.none): MultiAddress =
+  ## Remap addresses to new IP and/or Port
+  ##
+
+  var
+    parts = ($address).split("/")
+
+  parts[2] = if ip.isSome:
+      $ip.get
+    else:
+      parts[2]
+
+  parts[4] = if port.isSome:
+      $port.get
+    else:
+      parts[4]
+
+  MultiAddress.init(parts.join("/"))
+    .expect("Should construct multiaddress")

--- a/codex/utils/addrutils.nim
+++ b/codex/utils/addrutils.nim
@@ -10,7 +10,6 @@
 import pkg/upraises
 push: {.upraises: [].}
 
-import std/sequtils
 import std/strutils
 import std/options
 

--- a/codex/utils/keyutils.nim
+++ b/codex/utils/keyutils.nim
@@ -1,0 +1,50 @@
+
+## Nim-Codex
+## Copyright (c) 2022 Status Research & Development GmbH
+## Licensed under either of
+##  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+##  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+## at your option.
+## This file may not be copied, modified, or distributed except according to
+## those terms.
+
+import pkg/upraises
+push: {.upraises: [].}
+
+import std/os
+
+import pkg/chronicles
+import pkg/questionable/results
+import pkg/libp2p
+
+import ./fileutils
+import ../conf
+import ../errors
+import ../rng
+
+const
+  SafePermissions = {UserRead, UserWrite}
+
+type
+  CodexKeyError = object of CodexError
+  CodexKeyUnsafeError = object of CodexKeyError
+
+proc setupKey*(path: string): ?!PrivateKey =
+  if not path.fileAccessible({AccessFlags.Find}):
+    info "Creating a private key and saving it"
+    let
+      res = ? PrivateKey.random(Rng.instance()[]).mapFailure(CodexKeyError)
+      bytes = ? res.getBytes().mapFailure(CodexKeyError)
+
+    ? path.writeFile(bytes, SafePermissions.toInt()).mapFailure(CodexKeyError)
+    return PrivateKey.init(bytes).mapFailure(CodexKeyError)
+
+  info "Found a network private key"
+  if path.getPermissionsSet().get() != SafePermissions:
+    warn "The network private key file is not safe, aborting"
+    return failure newException(
+      CodexKeyUnsafeError, "The network private key file is not safe")
+
+  return PrivateKey.init(
+    ? path.readAllBytes().mapFailure(CodexKeyError))
+    .mapFailure(CodexKeyError)

--- a/tests/codex/helpers/nodeutils.nim
+++ b/tests/codex/helpers/nodeutils.nim
@@ -29,7 +29,10 @@ proc generateNodes*(
   for i in 0..<num:
     let
       switch = newStandardSwitch(transportFlags = {ServerFlags.ReuseAddr})
-      discovery = Discovery.new(switch.peerInfo.privateKey)
+      discovery = Discovery.new(
+        switch.peerInfo.privateKey,
+        announceAddrs = @[MultiAddress.init("/ip4/127.0.0.1/tcp/0")
+          .expect("Should return multiaddress")])
       wallet = WalletRef.example
       network = BlockExcNetwork.new(switch)
       localStore = CacheStore.new(blocks.mapIt( it ))

--- a/tests/codex/storageproofs/testnetwork.nim
+++ b/tests/codex/storageproofs/testnetwork.nim
@@ -81,8 +81,8 @@ suite "Storage Proofs Network":
     switch1 = newStandardSwitch()
     switch2 = newStandardSwitch()
 
-    discovery1 = MockDiscovery.new(switch1.peerInfo.privateKey)
-    discovery2 = MockDiscovery.new(switch2.peerInfo.privateKey)
+    discovery1 = MockDiscovery.new()
+    discovery2 = MockDiscovery.new()
 
     stpNetwork1 = StpNetwork.new(switch1, discovery1)
     stpNetwork2 = StpNetwork.new(switch2, discovery2)

--- a/tests/codex/testnode.nim
+++ b/tests/codex/testnode.nim
@@ -80,7 +80,10 @@ suite "Test Node":
     wallet = WalletRef.new(EthPrivateKey.random())
     network = BlockExcNetwork.new(switch)
     localStore = CacheStore.new()
-    blockDiscovery = Discovery.new(switch.peerInfo.privateKey)
+    blockDiscovery = Discovery.new(
+      switch.peerInfo.privateKey,
+      announceAddrs = @[MultiAddress.init("/ip4/127.0.0.1/tcp/0")
+        .expect("Should return multiaddress")])
     peerStore = PeerCtxStore.new()
     pendingBlocks = PendingBlocksManager.new()
     discovery = DiscoveryEngine.new(localStore, peerStore, network, blockDiscovery, pendingBlocks)

--- a/tests/testIntegration.nim
+++ b/tests/testIntegration.nim
@@ -1,4 +1,5 @@
 import std/osproc
+import std/os
 import std/httpclient
 import std/json
 import pkg/chronos
@@ -13,19 +14,27 @@ ethersuite "Integration tests":
   var baseurl1, baseurl2: string
   var client: HttpClient
 
+  let dataDir1 = getTempDir() / "Codex1"
+  let dataDir2 = getTempDir() / "Codex2"
+
   setup:
     await provider.getSigner(accounts[0]).mint()
     await provider.getSigner(accounts[1]).mint()
     await provider.getSigner(accounts[1]).deposit()
+
     node1 = startNode [
       "--api-port=8080",
-      "--udp-port=8090",
+      "--data-dir=" & dataDir1,
+      "--disc-ip=127.0.0.1",
+      "--disc-port=8090",
       "--persistence",
       "--eth-account=" & $accounts[0]
     ]
     node2 = startNode [
       "--api-port=8081",
-      "--udp-port=8091",
+      "--data-dir=" & dataDir2,
+      "--disc-ip=127.0.0.1",
+      "--disc-port=8091",
       "--persistence",
       "--eth-account=" & $accounts[1]
     ]
@@ -37,6 +46,9 @@ ethersuite "Integration tests":
     client.close()
     node1.stop()
     node2.stop()
+
+    dataDir1.removeDir()
+    dataDir2.removeDir()
 
   test "nodes can print their peer information":
     let info1 = client.get(baseurl1 & "/info").body


### PR DESCRIPTION
This PR adds support for persisting the private key. 

In addition it attempts to add more complete support for advertising and listening addresses. 

It adds the following options:

- `listen-addrs` - multiaddresses that the node listens on as well as announces as providers over the DHT. Making them multiaddresses allows listening on different transports, such as tcp and websockets, etc... 
  - After node startup, provider addresses are remapped with the IP set with `--nat`, this is done so that addresses are properly announced in case of `0.0.0.0`
- `nat` - allows specifying an external address and used when creating the bootstrap spr. (It should be extended to support more NAT related options, such as upnp, pmp, extip, etc...)
- `discoveryIp` and `discoveryPort` - bind ip and port for the DHT, note that the dht spr is also announced with the `--nat` provided address, instead of the `discoveryIp`