### PR TITLE
Block download

### DIFF
--- a/codex.nim
+++ b/codex.nim
@@ -43,7 +43,7 @@ when isMainModule:
       quit QuitFailure
 
     if config.nat == ValidIpAddress.init("127.0.0.1"):
-      warn "`--nat` is set to loopback, your node wont be properly announce over the DHT"
+      warn "`--nat` is set to loopback, your node wont properly announce over the DHT"
 
     if not(checkAndCreateDataDir((config.dataDir).string)):
       # We are unable to access/create data folder or data folder's

--- a/codex.nim
+++ b/codex.nim
@@ -89,9 +89,12 @@ when isMainModule:
       proc SIGTERMHandler(signal: cint) {.noconv.} =
         notice "Shutting down after having received SIGTERM"
         waitFor server.stop()
+        notice "Stopped Codex"
 
       c_signal(ansi_c.SIGTERM, SIGTERMHandler)
 
     waitFor server.start()
+    notice "Exited codex"
+
   of StartUpCommand.initNode:
     discard

--- a/codex.nim
+++ b/codex.nim
@@ -43,7 +43,7 @@ when isMainModule:
       quit QuitFailure
 
     if config.nat == ValidIpAddress.init("127.0.0.1"):
-      warn "`--nat` is set to local loopback, your node wont be properly announce over the DHT"
+      warn "`--nat` is set to loopback, your node wont be properly announce over the DHT"
 
     if not(checkAndCreateDataDir((config.dataDir).string)):
       # We are unable to access/create data folder or data folder's

--- a/codex/blockexchange/engine/discovery.nim
+++ b/codex/blockexchange/engine/discovery.nim
@@ -27,7 +27,7 @@ import ../../stores/blockstore
 import ./pendingblocks
 
 logScope:
-  topics = "codex discovery engine"
+  topics = "codex discoveryengine"
 
 declareGauge(codex_inflight_discovery, "inflight discovery requests")
 

--- a/codex/blockexchange/engine/engine.nim
+++ b/codex/blockexchange/engine/engine.nim
@@ -236,7 +236,7 @@ proc blockPresenceHandler*(
       not b.peers.anyIt( cid in it.peerHave ))
 
 proc scheduleTasks(b: BlockExcEngine, blocks: seq[bt.Block]) {.async.} =
-  trace "Schedule a task for new blocks"
+  trace "Schedule a task for new blocks", items = blocks.len
 
   let
     cids = blocks.mapIt( it.cid )

--- a/codex/blockexchange/engine/engine.nim
+++ b/codex/blockexchange/engine/engine.nim
@@ -279,7 +279,7 @@ proc payForBlocks(engine: BlockExcEngine,
 
 proc blocksHandler*(
   b: BlockExcEngine,
-  peer: PeerID,
+  peer: PeerId,
   blocks: seq[bt.Block]) {.async.} =
   ## handle incoming blocks
   ##
@@ -290,9 +290,13 @@ proc blocksHandler*(
       trace "Unable to store block", cid = blk.cid
 
   await b.resolveBlocks(blocks)
-  let peerCtx = b.peers.get(peer)
+  let
+    peerCtx = b.peers.get(peer)
+
   if peerCtx != nil:
+    # we don't care about this blocks anymore, lets cleanup the list
     await b.payForBlocks(peerCtx, blocks)
+    peerCtx.cleanPresence(blocks.mapIt( it.cid ))
 
 proc wantListHandler*(
   b: BlockExcEngine,

--- a/codex/blockexchange/engine/engine.nim
+++ b/codex/blockexchange/engine/engine.nim
@@ -500,7 +500,7 @@ proc new*(
       taskQueue: newAsyncHeapQueue[BlockExcPeerCtx](DefaultTaskQueueSize),
       discovery: discovery)
 
-  proc peerEventHandler(peerId: PeerID, event: PeerEvent) {.async.} =
+  proc peerEventHandler(peerId: PeerId, event: PeerEvent) {.async.} =
     if event.kind == PeerEventKind.Joined:
       await engine.setupPeer(peerId)
     else:
@@ -511,17 +511,17 @@ proc new*(
     network.switch.addPeerEventHandler(peerEventHandler, PeerEventKind.Left)
 
   proc blockWantListHandler(
-    peer: PeerID,
+    peer: PeerId,
     wantList: WantList): Future[void] {.gcsafe.} =
     engine.wantListHandler(peer, wantList)
 
   proc blockPresenceHandler(
-    peer: PeerID,
+    peer: PeerId,
     presence: seq[BlockPresence]): Future[void] {.gcsafe.} =
     engine.blockPresenceHandler(peer, presence)
 
   proc blocksHandler(
-    peer: PeerID,
+    peer: PeerId,
     blocks: seq[bt.Block]): Future[void] {.gcsafe.} =
     engine.blocksHandler(peer, blocks)
 

--- a/codex/blockexchange/engine/engine.nim
+++ b/codex/blockexchange/engine/engine.nim
@@ -33,7 +33,7 @@ import ./pendingblocks
 export peers, pendingblocks, payments, discovery
 
 logScope:
-  topics = "codex blockexc engine"
+  topics = "codex blockexcengine"
 
 const
   DefaultMaxPeersPerRequest* = 10

--- a/codex/blockexchange/engine/engine.nim
+++ b/codex/blockexchange/engine/engine.nim
@@ -440,7 +440,7 @@ proc taskHandler*(b: BlockExcEngine, task: BlockExcPeerCtx) {.gcsafe, async.} =
   if wantsBlocks.len > 0:
     trace "Got peer want blocks list", items = wantsBlocks.len
 
-    # wantsBlocks.sort(SortOrder.Descending) # TODO: why?
+    wantsBlocks.sort(SortOrder.Descending)
 
     let
       blockFuts = await allFinished(wantsBlocks.mapIt(

--- a/codex/blockexchange/engine/pendingblocks.nim
+++ b/codex/blockexchange/engine/pendingblocks.nim
@@ -21,7 +21,7 @@ import pkg/libp2p
 import ../../blocktype
 
 logScope:
-  topics = "codex blockexc pendingblocks"
+  topics = "codex pendingblocks"
 
 const
   DefaultBlockTimeout* = 10.minutes

--- a/codex/blockexchange/engine/pendingblocks.nim
+++ b/codex/blockexchange/engine/pendingblocks.nim
@@ -48,7 +48,7 @@ proc getWantHandle*(
         handle: newFuture[Block]("pendingBlocks.getWantHandle"),
         inFlight: inFlight)
 
-      trace "Adding pending future for block", cid
+      trace "Adding pending future for block", cid, inFlight = p.blocks[cid].inFlight
 
     return await p.blocks[cid].handle.wait(timeout)
   except CancelledError as exc:
@@ -76,15 +76,18 @@ proc resolve*(
 
 proc setInFlight*(
   p: PendingBlocksManager,
-  cid: Cid) =
+  cid: Cid,
+  inFlight = true) =
   p.blocks.withValue(cid, pending):
-    pending[].inFlight = true
+    pending[].inFlight = inFlight
+    trace "Setting inflight", cid, inFlight = pending[].inFlight
 
 proc isInFlight*(
   p: PendingBlocksManager,
   cid: Cid): bool =
   p.blocks.withValue(cid, pending):
     result = pending[].inFlight
+    trace "Getting inflight", cid, inFlight = result
 
 proc pending*(
   p: PendingBlocksManager,

--- a/codex/blockexchange/network/network.nim
+++ b/codex/blockexchange/network/network.nim
@@ -27,7 +27,7 @@ import ./networkpeer
 export network, payments
 
 logScope:
-  topics = "codex blockexc network"
+  topics = "codex blockexcnetwork"
 
 const
   Codec* = "/codex/blockexc/1.0.0"

--- a/codex/blockexchange/network/network.nim
+++ b/codex/blockexchange/network/network.nim
@@ -332,10 +332,11 @@ proc new*(
   ## Create a new BlockExcNetwork instance
   ##
 
-  let self = BlockExcNetwork(
-    switch: switch,
-    getConn: connProvider,
-    inflightSema: newAsyncSemaphore(maxInflight))
+  let
+    self = BlockExcNetwork(
+      switch: switch,
+      getConn: connProvider,
+      inflightSema: newAsyncSemaphore(maxInflight))
 
   proc sendWantList(
     id: PeerID,

--- a/codex/blockexchange/network/network.nim
+++ b/codex/blockexchange/network/network.nim
@@ -44,7 +44,7 @@ type
     cids: seq[Cid],
     priority: int32 = 0,
     cancel: bool = false,
-    wantType: WantType = WantType.wantHave,
+    wantType: WantType = WantType.WantHave,
     full: bool = false,
     sendDontHave: bool = false): Future[void] {.gcsafe.}
 
@@ -105,7 +105,7 @@ proc makeWantList*(
   cids: seq[Cid],
   priority: int = 0,
   cancel: bool = false,
-  wantType: WantType = WantType.wantHave,
+  wantType: WantType = WantType.WantHave,
   full: bool = false,
   sendDontHave: bool = false): WantList =
   WantList(
@@ -124,7 +124,7 @@ proc sendWantList*(
   cids: seq[Cid],
   priority: int32 = 0,
   cancel: bool = false,
-  wantType: WantType = WantType.wantHave,
+  wantType: WantType = WantType.WantHave,
   full: bool = false,
   sendDontHave: bool = false): Future[void] =
   ## Send a want message to peer
@@ -343,7 +343,7 @@ proc new*(
     cids: seq[Cid],
     priority: int32 = 0,
     cancel: bool = false,
-    wantType: WantType = WantType.wantHave,
+    wantType: WantType = WantType.WantHave,
     full: bool = false,
     sendDontHave: bool = false): Future[void] {.gcsafe.} =
     self.sendWantList(

--- a/codex/blockexchange/network/networkpeer.nim
+++ b/codex/blockexchange/network/networkpeer.nim
@@ -18,7 +18,7 @@ import ../protobuf/blockexc
 import ../../errors
 
 logScope:
-  topics = "codex blockexc networkpeer"
+  topics = "codex blockexcnetworkpeer"
 
 const
   MaxMessageSize = 100 * 1 shl 20 # manifest files can be big

--- a/codex/blockexchange/peers/peercontext.nim
+++ b/codex/blockexchange/peers/peercontext.nim
@@ -52,7 +52,7 @@ func cleanPresence*(self: BlockExcPeerCtx, cid: Cid) =
   self.cleanPresence(@[cid])
 
 func price*(self: BlockExcPeerCtx, cids: seq[Cid]): UInt256 =
-  var price = 0.UInt256
+  var price = 0.u256
   for cid in cids:
     self.blocks.withValue(cid, precense):
       price += precense[].price

--- a/codex/blockexchange/peers/peercontext.nim
+++ b/codex/blockexchange/peers/peercontext.nim
@@ -9,6 +9,8 @@
 
 import std/sequtils
 import std/tables
+
+import pkg/chronicles
 import pkg/libp2p
 import pkg/chronos
 import pkg/nitro
@@ -20,35 +22,40 @@ import ../protobuf/presence
 
 export payments, nitro
 
+logScope:
+  topics = "codex peercontext"
+
 type
   BlockExcPeerCtx* = ref object of RootObj
     id*: PeerID
-    peerPrices*: Table[Cid, UInt256]  # remote peer have list including price
+    blocks*: Table[Cid, Presence]     # remote peer have list including price
     peerWants*: seq[Entry]            # remote peers want lists
     exchanged*: int                   # times peer has exchanged with us
     lastExchange*: Moment             # last time peer has exchanged with us
     account*: ?Account                # ethereum account of this peer
     paymentChannel*: ?ChannelId       # payment channel id
 
-proc peerHave*(context: BlockExcPeerCtx): seq[Cid] =
-  toSeq(context.peerPrices.keys)
+proc peerHave*(self: BlockExcPeerCtx): seq[Cid] =
+  toSeq(self.blocks.keys)
 
-proc contains*(a: openArray[BlockExcPeerCtx], b: PeerID): bool =
-  ## Convenience method to check for peer prepense
-  ##
+proc contains*(self: BlockExcPeerCtx, cid: Cid): bool =
+  cid in self.blocks
 
-  a.anyIt( it.id == b )
+func setPresence*(self: BlockExcPeerCtx, presence: Presence) =
+  self.blocks[presence.cid] = presence
 
-func updatePresence*(context: BlockExcPeerCtx, presence: Presence) =
-  let cid = presence.cid
-  let price = presence.price
-
-  if cid notin context.peerHave and presence.have:
-    context.peerPrices[cid] = price
-  elif cid in context.peerHave and not presence.have:
-    context.peerPrices.del(cid)
-
-func price*(context: BlockExcPeerCtx, cids: seq[Cid]): UInt256 =
+func cleanPresence*(self: BlockExcPeerCtx, cids: seq[Cid]) =
   for cid in cids:
-    if price =? context.peerPrices.?[cid]:
-      result += price
+    self.blocks.del(cid)
+
+func cleanPresence*(self: BlockExcPeerCtx, cid: Cid) =
+  self.cleanPresence(@[cid])
+
+func price*(self: BlockExcPeerCtx, cids: seq[Cid]): UInt256 =
+  var price: UInt256
+  for cid in cids:
+    self.blocks.withValue(cid, precense):
+      price += precense[].price
+
+  trace "Blocks price", price
+

--- a/codex/blockexchange/peers/peercontext.nim
+++ b/codex/blockexchange/peers/peercontext.nim
@@ -52,10 +52,10 @@ func cleanPresence*(self: BlockExcPeerCtx, cid: Cid) =
   self.cleanPresence(@[cid])
 
 func price*(self: BlockExcPeerCtx, cids: seq[Cid]): UInt256 =
-  var price: UInt256
+  var price = 0.UInt256
   for cid in cids:
     self.blocks.withValue(cid, precense):
       price += precense[].price
 
   trace "Blocks price", price
-
+  price

--- a/codex/blockexchange/peers/peerctxstore.nim
+++ b/codex/blockexchange/peers/peerctxstore.nim
@@ -25,7 +25,7 @@ import ./peercontext
 export peercontext
 
 logScope:
-  topics = "codex blockexc peerctxstore"
+  topics = "codex peerctxstore"
 
 type
   PeerCtxStore* = ref object of RootObj

--- a/codex/blockexchange/peers/peerctxstore.nim
+++ b/codex/blockexchange/peers/peerctxstore.nim
@@ -35,6 +35,12 @@ iterator items*(self: PeerCtxStore): BlockExcPeerCtx =
   for p in self.peers.values:
     yield p
 
+proc contains*(a: openArray[BlockExcPeerCtx], b: PeerID): bool =
+  ## Convenience method to check for peer precense
+  ##
+
+  a.anyIt( it.id == b )
+
 func contains*(self: PeerCtxStore, peerId: PeerID): bool =
   peerId in self.peers
 
@@ -63,13 +69,21 @@ func selectCheapest*(self: PeerCtxStore, cid: Cid): seq[BlockExcPeerCtx] =
   var
     peers = self.peersHave(cid)
 
+  trace "Selecting cheapest peers", peers = peers.len
   func cmp(a, b: BlockExcPeerCtx): int =
-    # Can't do (a - b) without cast[int](a - b)
-    if a.peerPrices.getOrDefault(cid, 0.u256) ==
-      b.peerPrices.getOrDefault(cid, 0.u256):
+    var
+      priceA = 0.u256
+      priceB = 0.u256
+
+    a.blocks.withValue(cid, precense):
+      priceA = precense[].price
+
+    b.blocks.withValue(cid, precense):
+      priceB = precense[].price
+
+    if priceA == priceB:
       0
-    elif a.peerPrices.getOrDefault(cid, 0.u256) >
-      b.peerPrices.getOrDefault(cid, 0.u256):
+    elif priceA > priceB:
       1
     else:
       -1
@@ -79,4 +93,5 @@ func selectCheapest*(self: PeerCtxStore, cid: Cid): seq[BlockExcPeerCtx] =
   return peers
 
 proc new*(T: type PeerCtxStore): PeerCtxStore =
-  T(peers: initOrderedTable[PeerID, BlockExcPeerCtx]())
+  T(
+    peers: initOrderedTable[PeerID, BlockExcPeerCtx]())

--- a/codex/blockexchange/protobuf/message.nim
+++ b/codex/blockexchange/protobuf/message.nim
@@ -8,8 +8,8 @@ import pkg/libp2p/protobuf/minprotobuf
 
 type
   WantType* = enum
-    wantBlock = 0,
-    wantHave = 1
+    WantBlock = 0,
+    WantHave = 1
 
   Entry* = object
     `block`*: seq[byte]     # The block cid
@@ -27,8 +27,8 @@ type
     data*: seq[byte]
 
   BlockPresenceType* = enum
-    presenceHave = 0,
-    presenceDontHave = 1
+    Have = 0,
+    DontHave = 1
 
   BlockPresence* = object
     cid*: seq[byte]         # The block cid

--- a/codex/blockexchange/protobuf/presence.nim
+++ b/codex/blockexchange/protobuf/presence.nim
@@ -30,13 +30,16 @@ func init*(_: type Presence, message: PresenceMessage): ?Presence =
 
   some Presence(
     cid: cid,
-    have: message.`type` == presenceHave,
+    have: message.`type` == BlockPresenceType.Have,
     price: price
   )
 
 func init*(_: type PresenceMessage, presence: Presence): PresenceMessage =
   PresenceMessage(
     cid: presence.cid.data.buffer,
-    `type`: if presence.have: presenceHave else: presenceDontHave,
+    `type`: if presence.have:
+        BlockPresenceType.Have
+      else:
+        BlockPresenceType.DontHave,
     price: @(presence.price.toBytesBE)
   )

--- a/codex/blockexchange/protobuf/presence.nim
+++ b/codex/blockexchange/protobuf/presence.nim
@@ -18,13 +18,6 @@ type
     have*: bool
     price*: UInt256
 
-func init*(_: type PresenceMessage, presence: Presence): PresenceMessage =
-  PresenceMessage(
-    cid: presence.cid.data.buffer,
-    `type`: if presence.have: presenceHave else: presenceDontHave,
-    price: @(presence.price.toBytesBE)
-  )
-
 func parse(_: type UInt256, bytes: seq[byte]): ?UInt256 =
   if bytes.len > 32:
     return UInt256.none
@@ -39,4 +32,11 @@ func init*(_: type Presence, message: PresenceMessage): ?Presence =
     cid: cid,
     have: message.`type` == presenceHave,
     price: price
+  )
+
+func init*(_: type PresenceMessage, presence: Presence): PresenceMessage =
+  PresenceMessage(
+    cid: presence.cid.data.buffer,
+    `type`: if presence.have: presenceHave else: presenceDontHave,
+    price: @(presence.price.toBytesBE)
   )

--- a/codex/chunker.nim
+++ b/codex/chunker.nim
@@ -57,7 +57,7 @@ proc getBytes*(c: Chunker): Future[seq[byte]] {.async.} =
   if not c.pad and buff.len > read:
     buff.setLen(read)
 
-  return buff
+  return move buff
 
 func new*(
   T: type Chunker,

--- a/codex/codex.nim
+++ b/codex/codex.nim
@@ -75,7 +75,7 @@ proc start*(s: CodexServer) {.async.} =
   s.codexNode.discovery.updateAnnounceRecord(announceAddrs)
   s.codexNode.discovery.updateDhtRecord(s.config.nat, s.config.discoveryPort)
 
-  s.runHandle = newFuture[void]()
+  s.runHandle = newFuture[void]("codex.runHandle")
   await s.runHandle
 
 proc stop*(s: CodexServer) {.async.} =
@@ -116,7 +116,7 @@ proc new*(T: type CodexServer, config: CodexConf, privateKey: CodexPrivateKey): 
     .build()
 
   var
-    cache: CacheStore
+    cache: CacheStore = nil
 
   if config.cacheSize > 0:
     cache = CacheStore.new(cacheSize = config.cacheSize * MiB)

--- a/codex/conf.nim
+++ b/codex/conf.nim
@@ -143,9 +143,9 @@ type
         abbr: "p" }: int
 
       cacheSize* {.
-        desc: "The size in MiB of the block cache, 0 disables the cache"
-        defaultValue: DefaultCacheSizeMiB
-        defaultValueDesc: $DefaultCacheSizeMiB
+        desc: "The size in MiB of the block cache, 0 disables the cache - might help on slow hardrives"
+        defaultValue: 0
+        defaultValueDesc: "0"
         name: "cache-size"
         abbr: "c" }: Natural
 

--- a/codex/erasure/erasure.nim
+++ b/codex/erasure/erasure.nim
@@ -109,7 +109,7 @@ proc encode*(
       # TODO: this is a tight blocking loop so we sleep here to allow
       # other events to be processed, this should be addressed
       # by threading
-      await sleepAsync(100.millis)
+      await sleepAsync(10.millis)
 
       for j in 0..<blocks:
         let idx = blockIdx[j]

--- a/codex/node.nim
+++ b/codex/node.nim
@@ -147,18 +147,20 @@ proc retrieve*(
   let
     stream = BufferStream.new()
 
-  if blkOrNone =? (await node.blockStore.getBlock(cid)) and blk =? blkOrNone:
-    proc streamOneBlock(): Future[void] {.async.} =
-      try:
-        await stream.pushData(blk.data)
-      except CatchableError as exc:
-        trace "Unable to send block", cid
-        discard
-      finally:
-        await stream.pushEof()
+  without blk =? (await node.blockStore.getBlock(cid)), err:
+    return failure(err)
 
-    asyncSpawn streamOneBlock()
-    return LPStream(stream).success()
+  proc streamOneBlock(): Future[void] {.async.} =
+    try:
+      await stream.pushData(blk.data)
+    except CatchableError as exc:
+      trace "Unable to send block", cid
+      discard
+    finally:
+      await stream.pushEof()
+
+  asyncSpawn streamOneBlock()
+  return LPStream(stream).success()
 
   return failure("Unable to retrieve Cid!")
 
@@ -210,14 +212,14 @@ proc store*(
     return failure("Unable to init block from manifest data!")
 
   if isErr (await node.blockStore.putBlock(manifest)):
-    trace "Unable to store manifest", cid = $manifest.cid
+    trace "Unable to store manifest", cid = manifest.cid
     return failure("Unable to store manifest " & $manifest.cid)
 
   without cid =? blockManifest.cid, error:
     trace "Unable to generate manifest Cid!", exc = error.msg
     return failure(error.msg)
 
-  trace "Stored data", manifestCid = $manifest.cid,
+  trace "Stored data", manifestCid = manifest.cid,
                        contentCid = cid,
                        blocks = blockManifest.len
 
@@ -263,7 +265,7 @@ proc requestStorage*(self: CodexNodeRef,
     return failure(error)
 
   if isErr (await self.blockStore.putBlock(encodedBlk)):
-    trace "Unable to store encoded manifest block", cid = $encodedBlk.cid
+    trace "Unable to store encoded manifest block", cid = encodedBlk.cid
     return failure("Unable to store encoded manifest block")
 
   let request = StorageRequest(

--- a/codex/stores/cachestore.nim
+++ b/codex/stores/cachestore.nim
@@ -40,7 +40,7 @@ type
 
 const
   MiB* = 1024 * 1024 # bytes, 1 mebibyte = 1,048,576 bytes
-  DefaultCacheSizeMiB* = 100
+  DefaultCacheSizeMiB* = 5
   DefaultCacheSize* = DefaultCacheSizeMiB * MiB # bytes
 
 method getBlock*(self: CacheStore, cid: Cid): Future[?!Block] {.async.} =

--- a/codex/stores/fsstore.nim
+++ b/codex/stores/fsstore.nim
@@ -185,7 +185,8 @@ method listBlocks*(self: FSStore, onBlock: OnBlock): Future[?!void] {.async.} =
     for (fkind, filename) in folderPath.walkDir(relative = true):
       if fkind != pcFile: continue
       let cid = Cid.init(filename)
-      if cid.isOk: await onBlock(cid.get())
+      if cid.isOk:
+        await onBlock(cid.get())
 
   return success()
 
@@ -199,7 +200,7 @@ proc new*(
   T: type FSStore,
   repoDir: string,
   postfixLen = 2,
-  cache: BlockStore = CacheStore.new()): T =
+  cache: BlockStore = nil): T =
   T(
     postfixLen: postfixLen,
     repoDir: repoDir,

--- a/codex/streams/storestream.nim
+++ b/codex/streams/storestream.nim
@@ -69,7 +69,7 @@ method readOnce*(
   ## Return how many bytes were actually read before EOF was encountered.
   ## Raise exception if we are already at EOF.
 
-  trace "Reading from manifest", cid = $self.manifest.cid.get(), blocks = self.manifest.len
+  trace "Reading from manifest", cid = self.manifest.cid.get(), blocks = self.manifest.len
   if self.atEof:
     raise newLPStreamEOFError()
 

--- a/codex/streams/storestream.nim
+++ b/codex/streams/storestream.nim
@@ -27,7 +27,7 @@ import ./seekablestream
 export stores, blocktype, manifest, chronos
 
 logScope:
-  topics = "dagger storestream"
+  topics = "codex storestream"
 
 type
   # Make SeekableStream from a sequence of blocks stored in Manifest

--- a/tests/codex/blockexchange/discovery/testdiscovery.nim
+++ b/tests/codex/blockexchange/discovery/testdiscovery.nim
@@ -111,12 +111,13 @@ suite "Block Advertising and Discovery":
       )
       peerId = PeerID.example
       haves = collect(initTable()):
-        for blk in blocks: {blk.cid: 0.u256}
+        for blk in blocks:
+          { blk.cid: Presence(cid: blk.cid, price: 0.u256) }
 
     engine.peers.add(
       BlockExcPeerCtx(
         id: peerId,
-        peerPrices: haves
+        blocks: haves
     ))
 
     blockDiscovery.findBlockProvidersHandler =

--- a/tests/codex/blockexchange/discovery/testdiscoveryengine.nim
+++ b/tests/codex/blockexchange/discovery/testdiscoveryengine.nim
@@ -150,12 +150,13 @@ suite "Test Discovery Engine":
 
     blockDiscovery.findBlockProvidersHandler =
       proc(d: MockDiscovery, cid: Cid): Future[seq[SignedPeerRecord]] {.async, gcsafe.} =
+
         check cid == blocks[0].cid
         check peerStore.len < minPeers
         var
           peerCtx = BlockExcPeerCtx(id: PeerID.example)
 
-        peerCtx.blocks[cid].price = 0.u256
+        peerCtx.blocks[cid] = Presence(cid: cid, price: 0.u256)
         peerStore.add(peerCtx)
         want.fire()
 

--- a/tests/codex/blockexchange/discovery/testdiscoveryengine.nim
+++ b/tests/codex/blockexchange/discovery/testdiscoveryengine.nim
@@ -155,7 +155,7 @@ suite "Test Discovery Engine":
         var
           peerCtx = BlockExcPeerCtx(id: PeerID.example)
 
-        peerCtx.peerPrices[cid] = 0.u256
+        peerCtx.blocks[cid].price = 0.u256
         peerStore.add(peerCtx)
         want.fire()
 

--- a/tests/codex/blockexchange/engine/testblockexc.nim
+++ b/tests/codex/blockexchange/engine/testblockexc.nim
@@ -129,7 +129,7 @@ suite "NetworkStore engine - 2 nodes":
       `block`: blk.cid.data.buffer,
       priority: 1,
       cancel: false,
-      wantType: WantType.wantBlock,
+      wantType: WantType.WantBlock,
       sendDontHave: false)
 
     peerCtx1.peerWants.add(entry)

--- a/tests/codex/blockexchange/engine/testblockexc.nim
+++ b/tests/codex/blockexchange/engine/testblockexc.nim
@@ -253,9 +253,6 @@ suite "NetworkStore - multiple nodes":
           .mapIt( $it.read.get.cid ).sorted(cmp[string]) ==
         downloadCids.mapIt( $it ).sorted(cmp[string])
 
-  test "TODO - Should exchange want lists when more then 2 nodes connected":
-    discard
-
   test "Should exchange blocks with multiple nodes":
     let
       downloader = networkStore[4]

--- a/tests/codex/blockexchange/engine/testblockexc.nim
+++ b/tests/codex/blockexchange/engine/testblockexc.nim
@@ -20,8 +20,8 @@ import ../../helpers
 
 suite "NetworkStore engine - 2 nodes":
   let
-    chunker1 = RandomChunker.new(Rng.instance(), size = 1024, chunkSize = 256)
-    chunker2 = RandomChunker.new(Rng.instance(), size = 1024, chunkSize = 256)
+    chunker1 = RandomChunker.new(Rng.instance(), size = 2048, chunkSize = 256)
+    chunker2 = RandomChunker.new(Rng.instance(), size = 2048, chunkSize = 256)
 
   var
     nodeCmps1, nodeCmps2: NodesComponents
@@ -57,8 +57,13 @@ suite "NetworkStore engine - 2 nodes":
       nodeCmps2.engine.start())
 
     # initialize our want lists
-    pendingBlocks1 = blocks2.mapIt( nodeCmps1.pendingBlocks.getWantHandle( it.cid ) )
-    pendingBlocks2 = blocks1.mapIt( nodeCmps2.pendingBlocks.getWantHandle( it.cid ) )
+    pendingBlocks1 = blocks2[0..3].mapIt(
+      nodeCmps1.pendingBlocks.getWantHandle( it.cid )
+    )
+
+    pendingBlocks2 = blocks1[0..3].mapIt(
+      nodeCmps2.pendingBlocks.getWantHandle( it.cid )
+    )
 
     pricing1 = Pricing.example()
     pricing2 = Pricing.example()
@@ -88,7 +93,7 @@ suite "NetworkStore engine - 2 nodes":
       nodeCmps2.engine.stop(),
       nodeCmps2.switch.stop())
 
-  test "Should exchange want lists on connect":
+  test "Should exchange blocks on connect":
     await allFuturesThrowing(
       allFinished(pendingBlocks1))
       .wait(10.seconds)
@@ -98,11 +103,19 @@ suite "NetworkStore engine - 2 nodes":
       .wait(10.seconds)
 
     check:
-      peerCtx1.peerHave.mapIt( $it ).sorted(cmp[string]) ==
-        pendingBlocks2.mapIt( $it.read.cid ).sorted(cmp[string])
+      (await allFinished(
+        blocks1[0..3].mapIt(
+          nodeCmps2.localStore.getBlock( it.cid ) )))
+          .filterIt( it.completed and it.read.isOk )
+          .mapIt( $it.read.get.cid ).sorted(cmp[string]) ==
+        blocks1[0..3].mapIt( $it.cid ).sorted(cmp[string])
 
-      peerCtx2.peerHave.mapIt( $it ).sorted(cmp[string]) ==
-        pendingBlocks1.mapIt( $it.read.cid ).sorted(cmp[string])
+      (await allFinished(
+        blocks2[0..3].mapIt(
+          nodeCmps1.localStore.getBlock( it.cid ) )))
+          .filterIt( it.completed and it.read.isOk )
+          .mapIt( $it.read.get.cid ).sorted(cmp[string]) ==
+        blocks2[0..3].mapIt( $it.cid ).sorted(cmp[string])
 
   test "Should exchanges accounts on connect":
     check peerCtx1.account.?address == pricing1.address.some
@@ -128,16 +141,19 @@ suite "NetworkStore engine - 2 nodes":
     check eventually (await nodeCmps1.localStore.hasBlock(blk.cid)).tryGet()
 
   test "Should get blocks from remote":
-    let blocks = await allFinished(
-      blocks2.mapIt( nodeCmps1.networkStore.getBlock(it.cid) ))
-    check blocks.mapIt( it.read().tryGet() ) == blocks2
+    let
+      blocks = await allFinished(
+        blocks2[4..7].mapIt(
+          nodeCmps1.networkStore.getBlock(it.cid)
+      ))
+
+    check blocks.mapIt( it.read().tryGet() ) == blocks2[4..7]
 
   test "Remote should send blocks when available":
     let blk = bt.Block.new("Block 1".toBytes).tryGet()
 
     # should fail retrieving block from remote
-    check not await nodeCmps1.networkStore.getBlock(blk.cid)
-      .withTimeout(100.millis) # should expire
+    check not await blk.cid in nodeCmps1.networkStore
 
     # second trigger blockexc to resolve any pending requests
     # for the block
@@ -147,18 +163,25 @@ suite "NetworkStore engine - 2 nodes":
     check await nodeCmps1.networkStore.getBlock(blk.cid)
       .withTimeout(100.millis) # should succeed
 
-  test "Should receive payments for blocks that were sent":
-    # delete on node1 cached blocks from node2
-    discard await allFinished(
-      blocks2.mapIt( nodeCmps1.networkStore.delBlock(it.cid) ))
+  # test "Should receive payments for blocks that were sent":
+  #   discard await allFinished(
+  #     blocks2[4..7].mapIt(
+  #       nodeCmps2.networkStore.putBlock(it)
+  #   ))
 
-    let blocks = await allFinished(
-      blocks2.mapIt( nodeCmps1.networkStore.getBlock(it.cid) ))
+  #   let
+  #     blocks = await allFinished(
+  #       blocks2[4..7].mapIt(
+  #         nodeCmps1.networkStore.getBlock(it.cid)
+  #     ))
 
-    let channel = !peerCtx1.paymentChannel
-    let wallet = nodeCmps2.wallet
+  #   await sleepAsync(10.seconds)
 
-    check eventually wallet.balance(channel, Asset) > 0
+  #   let
+  #     channel = !peerCtx1.paymentChannel
+  #     wallet = nodeCmps2.wallet
+
+  #   check eventually wallet.balance(channel, Asset) > 0
 
 suite "NetworkStore - multiple nodes":
   let
@@ -194,15 +217,24 @@ suite "NetworkStore - multiple nodes":
     switch = @[]
     networkStore = @[]
 
-  test "Should receive haves for own want list":
+  test "Should receive blocks for own want list":
     let
       downloader = networkStore[4]
       engine = downloader.engine
 
     # Add blocks from 1st peer to want list
     let
-      pendingBlocks1 = blocks[0..3].mapIt( engine.pendingBlocks.getWantHandle( it.cid ) )
-      pendingBlocks2 = blocks[12..15].mapIt( engine.pendingBlocks.getWantHandle( it.cid ))
+      downloadCids =
+        blocks[0..3].mapIt(
+          it.cid
+        ) &
+        blocks[12..15].mapIt(
+          it.cid
+        )
+
+      pendingBlocks = downloadCids.mapIt(
+        engine.pendingBlocks.getWantHandle( it )
+      )
 
     for i in 0..15:
       (await networkStore[i div 4].engine.localStore.putBlock(blocks[i])).tryGet()
@@ -211,18 +243,18 @@ suite "NetworkStore - multiple nodes":
     await sleepAsync(1.seconds)
 
     await allFuturesThrowing(
-      allFinished(pendingBlocks1),
-      allFinished(pendingBlocks2))
-
-    let
-      peers = toSeq(engine.peers)
+      allFinished(pendingBlocks))
 
     check:
-      peers[0].peerHave.mapIt($it).sorted(cmp[string]) ==
-        blocks[0..3].mapIt( $(it.cid) ).sorted(cmp[string])
+      (await allFinished(
+        downloadCids.mapIt(
+          downloader.localStore.getBlock( it ) )))
+          .filterIt( it.completed and it.read.isOk )
+          .mapIt( $it.read.get.cid ).sorted(cmp[string]) ==
+        downloadCids.mapIt( $it ).sorted(cmp[string])
 
-      peers[3].peerHave.mapIt($it).sorted(cmp[string]) ==
-        blocks[12..15].mapIt( $(it.cid) ).sorted(cmp[string])
+  test "TODO - Should exchange want lists when more then 2 nodes connected":
+    discard
 
   test "Should exchange blocks with multiple nodes":
     let
@@ -231,8 +263,12 @@ suite "NetworkStore - multiple nodes":
 
     # Add blocks from 1st peer to want list
     let
-      pendingBlocks1 = blocks[0..3].mapIt( engine.pendingBlocks.getWantHandle( it.cid ) )
-      pendingBlocks2 = blocks[12..15].mapIt( engine.pendingBlocks.getWantHandle( it.cid ))
+      pendingBlocks1 = blocks[0..3].mapIt(
+        engine.pendingBlocks.getWantHandle( it.cid )
+      )
+      pendingBlocks2 = blocks[12..15].mapIt(
+        engine.pendingBlocks.getWantHandle( it.cid )
+      )
 
     for i in 0..15:
       (await networkStore[i div 4].engine.localStore.putBlock(blocks[i])).tryGet()

--- a/tests/codex/blockexchange/engine/testblockexc.nim
+++ b/tests/codex/blockexchange/engine/testblockexc.nim
@@ -163,25 +163,25 @@ suite "NetworkStore engine - 2 nodes":
     check await nodeCmps1.networkStore.getBlock(blk.cid)
       .withTimeout(100.millis) # should succeed
 
-  # test "Should receive payments for blocks that were sent":
-  #   discard await allFinished(
-  #     blocks2[4..7].mapIt(
-  #       nodeCmps2.networkStore.putBlock(it)
-  #   ))
+  test "Should receive payments for blocks that were sent":
+    discard await allFinished(
+      blocks2[4..7].mapIt(
+        nodeCmps2.networkStore.putBlock(it)
+    ))
 
-  #   let
-  #     blocks = await allFinished(
-  #       blocks2[4..7].mapIt(
-  #         nodeCmps1.networkStore.getBlock(it.cid)
-  #     ))
+    let
+      blocks = await allFinished(
+        blocks2[4..7].mapIt(
+          nodeCmps1.networkStore.getBlock(it.cid)
+      ))
 
-  #   await sleepAsync(10.seconds)
+    # await sleepAsync(10.seconds)
 
-  #   let
-  #     channel = !peerCtx1.paymentChannel
-  #     wallet = nodeCmps2.wallet
+    let
+      channel = !peerCtx1.paymentChannel
+      wallet = nodeCmps2.wallet
 
-  #   check eventually wallet.balance(channel, Asset) > 0
+    check eventually wallet.balance(channel, Asset) > 0
 
 suite "NetworkStore - multiple nodes":
   let

--- a/tests/codex/blockexchange/engine/testengine.nim
+++ b/tests/codex/blockexchange/engine/testengine.nim
@@ -285,33 +285,35 @@ suite "NetworkStore engine handlers":
       let present = await engine.localStore.hasBlock(b.cid)
       check present.tryGet()
 
-  # test "Should send payments for received blocks":
-  #   let
-  #     account = Account(address: EthAddress.example)
-  #     peerContext = peerStore.get(peerId)
+  test "Should send payments for received blocks":
+    let
+      done = newFuture[void]()
+      account = Account(address: EthAddress.example)
+      peerContext = peerStore.get(peerId)
 
-  #   peerContext.account = account.some
-  #   peerContext.blocks = blocks.mapIt(
-  #     (it.cid, Presence(cid: it.cid, price: rand(uint16).u256))
-  #   ).toTable
+    peerContext.account = account.some
+    peerContext.blocks = blocks.mapIt(
+      (it.cid, Presence(cid: it.cid, price: rand(uint16).u256))
+    ).toTable
 
-  #   engine.network = BlockExcNetwork(request: BlockExcRequest(
-  #     sendPayment: proc(receiver: PeerID, payment: SignedState) {.gcsafe, async.} =
-  #       let
-  #         amount =
-  #           blocks.mapIt(
-  #             peerContext.blocks[it.cid].price
-  #           ).foldl(a + b)
+    engine.network = BlockExcNetwork(
+      request: BlockExcRequest(
+        sendPayment: proc(receiver: PeerID, payment: SignedState) {.gcsafe, async.} =
+          let
+            amount =
+              blocks.mapIt(
+                peerContext.blocks[it.cid].price
+              ).foldl(a + b)
 
-  #         balances = !payment.state.outcome.balances(Asset)
+            balances = !payment.state.outcome.balances(Asset)
 
-  #       check receiver == peerId
-  #       check balances[account.address.toDestination] == amount
-  #       done.complete()
-  #   ))
+          check receiver == peerId
+          check balances[account.address.toDestination] == amount
+          done.complete()
+    ))
 
-  #   await engine.blocksHandler(peerId, blocks)
-  #   await done.wait(100.millis)
+    await engine.blocksHandler(peerId, blocks)
+    await done.wait(100.millis)
 
   test "Should handle block presence":
     var

--- a/tests/codex/blockexchange/engine/testengine.nim
+++ b/tests/codex/blockexchange/engine/testengine.nim
@@ -58,7 +58,7 @@ suite "NetworkStore engine basic":
       cids: seq[Cid],
       priority: int32 = 0,
       cancel: bool = false,
-      wantType: WantType = WantType.wantHave,
+      wantType: WantType = WantType.WantHave,
       full: bool = false,
       sendDontHave: bool = false) {.gcsafe, async.} =
         check cids.mapIt($it).sorted == blocks.mapIt( $it.cid ).sorted
@@ -188,7 +188,7 @@ suite "NetworkStore engine handlers":
     let
       wantList = makeWantList(
         blocks.mapIt( it.cid ),
-        wantType = WantType.wantBlock) # only `wantBlock` are stored in `peerWants`
+        wantType = WantType.WantBlock) # only `wantBlock` are stored in `peerWants`
 
     proc handler() {.async.} =
       let ctx = await engine.taskQueue.pop()
@@ -231,7 +231,7 @@ suite "NetworkStore engine handlers":
       check presence.mapIt( it.cid ) == wantList.entries.mapIt( it.`block` )
       for p in presence:
         check:
-          p.`type` == BlockPresenceType.presenceDontHave
+          p.`type` == BlockPresenceType.DontHave
 
       done.complete()
 
@@ -256,9 +256,9 @@ suite "NetworkStore engine handlers":
 
       for p in presence:
         if p.cid != cid1Buf and p.cid != cid2Buf:
-          check p.`type` == BlockPresenceType.presenceDontHave
+          check p.`type` == BlockPresenceType.DontHave
         else:
-          check p.`type` == BlockPresenceType.presenceHave
+          check p.`type` == BlockPresenceType.Have
 
       done.complete()
 
@@ -324,7 +324,7 @@ suite "NetworkStore engine handlers":
       cids: seq[Cid],
       priority: int32 = 0,
       cancel: bool = false,
-      wantType: WantType = WantType.wantHave,
+      wantType: WantType = WantType.WantHave,
       full: bool = false,
       sendDontHave: bool = false) {.gcsafe, async.} =
         engine.pendingBlocks.resolve(blocks.filterIt( it.cid in cids ))
@@ -439,7 +439,7 @@ suite "Task Handler":
         `block`: blocks[0].cid.data.buffer,
         priority: 49,
         cancel: false,
-        wantType: WantType.wantBlock,
+        wantType: WantType.WantBlock,
         sendDontHave: false)
     )
 
@@ -449,7 +449,7 @@ suite "Task Handler":
         `block`: blocks[1].cid.data.buffer,
         priority: 50,
         cancel: false,
-        wantType: WantType.wantBlock,
+        wantType: WantType.WantBlock,
         sendDontHave: false)
     )
 
@@ -477,7 +477,7 @@ suite "Task Handler":
         `block`: present[0].cid.data.buffer,
         priority: 1,
         cancel: false,
-        wantType: WantType.wantHave,
+        wantType: WantType.WantHave,
         sendDontHave: false)
     )
 
@@ -487,7 +487,7 @@ suite "Task Handler":
         `block`: present[1].cid.data.buffer,
         priority: 1,
         cancel: false,
-        wantType: WantType.wantHave,
+        wantType: WantType.WantHave,
         sendDontHave: false)
     )
 
@@ -497,7 +497,7 @@ suite "Task Handler":
         `block`: missing[0].cid.data.buffer,
         priority: 1,
         cancel: false,
-        wantType: WantType.wantHave,
+        wantType: WantType.WantHave,
         sendDontHave: false)
     )
 

--- a/tests/codex/blockexchange/protobuf/testpresence.nim
+++ b/tests/codex/blockexchange/protobuf/testpresence.nim
@@ -18,9 +18,9 @@ suite "block presence protobuf messages":
   test "encodes have/donthave":
     var presence = presence
     presence.have = true
-    check PresenceMessage.init(presence).`type` == presenceHave
+    check PresenceMessage.init(presence).`type` == Have
     presence.have = false
-    check PresenceMessage.init(presence).`type` == presenceDontHave
+    check PresenceMessage.init(presence).`type` == DontHave
 
   test "encodes price":
     check message.price == @(price.toBytesBE)
@@ -35,9 +35,9 @@ suite "block presence protobuf messages":
 
   test "decodes have/donthave":
     var message = message
-    message.`type` = presenceHave
+    message.`type` = BlockPresenceType.Have
     check Presence.init(message).?have == true.some
-    message.`type` = presenceDontHave
+    message.`type` = BlockPresenceType.DontHave
     check Presence.init(message).?have == false.some
 
   test "decodes price":

--- a/tests/codex/blockexchange/testnetwork.nim
+++ b/tests/codex/blockexchange/testnetwork.nim
@@ -56,7 +56,7 @@ suite "Network - Handlers":
       for b in blocks:
         check b.cid in wantList.entries
         let entry = wantList.entries[wantList.entries.find(b.cid)]
-        check entry.wantType == WantType.wantHave
+        check entry.wantType == WantType.WantHave
         check entry.priority == 1
         check entry.cancel == true
         check entry.sendDontHave == true
@@ -67,7 +67,7 @@ suite "Network - Handlers":
 
     let wantList = makeWantList(
       blocks.mapIt( it.cid ),
-      1, true, WantType.wantHave,
+      1, true, WantType.WantHave,
       true, true)
 
     let msg = Message(wantlist: wantList)
@@ -103,7 +103,7 @@ suite "Network - Handlers":
       blockPresences: blocks.mapIt(
         BlockPresence(
           cid: it.cid.data.buffer,
-          type: BlockPresenceType.presenceHave
+          type: BlockPresenceType.Have
       )))
     await buffer.pushData(lenPrefix(ProtobufEncode(msg)))
 
@@ -186,7 +186,7 @@ suite "Network - Senders":
       for b in blocks:
         check b.cid in wantList.entries
         let entry = wantList.entries[wantList.entries.find(b.cid)]
-        check entry.wantType == WantType.wantHave
+        check entry.wantType == WantType.WantHave
         check entry.priority == 1
         check entry.cancel == true
         check entry.sendDontHave == true
@@ -197,7 +197,7 @@ suite "Network - Senders":
     await network1.sendWantList(
       switch2.peerInfo.peerId,
       blocks.mapIt( it.cid ),
-      1, true, WantType.wantHave,
+      1, true, WantType.WantHave,
       true, true)
 
     await done.wait(500.millis)
@@ -231,7 +231,7 @@ suite "Network - Senders":
       blocks.mapIt(
         BlockPresence(
           cid: it.cid.data.buffer,
-          type: BlockPresenceType.presenceHave
+          type: BlockPresenceType.Have
       )))
 
     await done.wait(500.millis)

--- a/tests/codex/blockexchange/testpeerctxstore.nim
+++ b/tests/codex/blockexchange/testpeerctxstore.nim
@@ -6,6 +6,7 @@ import pkg/libp2p
 
 import pkg/codex/blockexchange/peers
 import pkg/codex/blockexchange/protobuf/blockexc
+import pkg/codex/blockexchange/protobuf/presence
 
 import ../examples
 
@@ -52,13 +53,13 @@ suite "Peer Context Store Peer Selection":
     peerCtxs = @[]
 
   test "Should select peers that have Cid":
-    peerCtxs[0].peerPrices = collect(initTable):
+    peerCtxs[0].blocks = collect(initTable):
       for i, c in cids:
-        { c: i.u256 }
+        { c: Presence(cid: c, price: i.u256) }
 
-    peerCtxs[5].peerPrices = collect(initTable):
+    peerCtxs[5].blocks = collect(initTable):
       for i, c in cids:
-        { c: i.u256 }
+        { c: Presence(cid: c, price: i.u256) }
 
     let
       peers = store.peersHave(cids[0])
@@ -68,17 +69,17 @@ suite "Peer Context Store Peer Selection":
     check peerCtxs[5] in peers
 
   test "Should select cheapest peers for Cid":
-    peerCtxs[0].peerPrices = collect(initTable):
+    peerCtxs[0].blocks = collect(initTable):
       for i, c in cids:
-        { c: (5 + i).u256 }
+        { c: Presence(cid: c, price: (5 + i).u256) }
 
-    peerCtxs[5].peerPrices = collect(initTable):
+    peerCtxs[5].blocks = collect(initTable):
       for i, c in cids:
-        { c: (2 + i).u256 }
+        { c: Presence(cid: c, price: (2 + i).u256) }
 
-    peerCtxs[9].peerPrices = collect(initTable):
+    peerCtxs[9].blocks = collect(initTable):
       for i, c in cids:
-        { c: i.u256 }
+        { c: Presence(cid: c, price: i.u256) }
 
     let
       peers = store.selectCheapest(cids[0])

--- a/tests/codex/blockexchange/testpeerctxstore.nim
+++ b/tests/codex/blockexchange/testpeerctxstore.nim
@@ -96,7 +96,7 @@ suite "Peer Context Store Peer Selection":
           `block`: it.data.buffer,
           priority: 1,
           cancel: false,
-          wantType: WantType.wantBlock,
+          wantType: WantType.WantBlock,
           sendDontHave: false))
 
     peerCtxs[0].peerWants = entries


### PR DESCRIPTION
The current implementation has several flaws that lead to download performance degradation with more than one peer. This PR attempts to address some of this issues.

- [x] Fix `Futures` and `Block` mem leak
- [x] Improve  transfer speeds by limiting the number of cached remote block info
  - Current transfer is around ~10MB/s, this can be further improved with parallel downloads and similar
- [x] Improve overall memory usage - currently downloading 8GB file will steadily however at around 280MB
- [x] Improve/increase logging
