### PR TITLE
Fix CI

### DIFF
--- a/.github/actions/nimbus-build-system/action.yml
+++ b/.github/actions/nimbus-build-system/action.yml
@@ -9,7 +9,7 @@ inputs:
   cpu:
     description: "CPU to build for"
     default: "amd64"
-  nim_branch:
+  nim_version:
     description: "Nim version"
     default: "version-1-6"
   shell:
@@ -153,12 +153,12 @@ runs:
       uses: actions/cache@v3
       with:
         path: NimBinaries
-        key: ${{ inputs.os }}-${{ inputs.cpu }}-nim-${{ inputs.nim_branch }}-cache-${{ env.cache_nonce }}-${{ github.run_id }}
-        restore-keys: ${{ inputs.os }}-${{ inputs.cpu }}-nim-${{ inputs.nim_branch }}-cache-${{ env.cache_nonce }}
+        key: ${{ inputs.os }}-${{ inputs.cpu }}-nim-${{ inputs.nim_version }}-cache-${{ env.cache_nonce }}-${{ github.run_id }}
+        restore-keys: ${{ inputs.os }}-${{ inputs.cpu }}-nim-${{ inputs.nim_version }}-cache-${{ env.cache_nonce }}
 
     - name: Set NIM_COMMIT
       shell: ${{ inputs.shell }} {0}
-      run: echo "NIM_COMMIT=${{ inputs.nim_branch }}" >> ${GITHUB_ENV}
+      run: echo "NIM_COMMIT=${{ inputs.nim_version }}" >> ${GITHUB_ENV}
 
     - name: Build Nim and Codex dependencies
       shell: ${{ inputs.shell }} {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 env:
   cache_nonce: 0 # Allows for easily busting actions/cache caches
+  nim_version: v1.6.10
 jobs:
   build:
     strategy:
@@ -41,6 +42,7 @@ jobs:
         with:
           os: ${{ matrix.os }}
           shell: ${{ matrix.shell }}
+          nim_version: ${{ env.nim_version }}
 
       - name: Unit tests
         run: make -j${ncpu} test
@@ -73,6 +75,7 @@ jobs:
         uses: ./.github/actions/nimbus-build-system
         with:
           os: linux
+          nim_version: ${{ env.nim_version }}
 
       - name: Generate coverage data
         run: make -j${ncpu} coverage
@@ -100,7 +103,7 @@ jobs:
         uses: ./.github/actions/nimbus-build-system
         with:
           os: linux
-          nim_branch: version-1-2
+          nim_version: version-1-2
 
       - name: Unit tests
         run: make -j${ncpu} test


### PR DESCRIPTION
Fixes issue when trying to fetch recent commits/branches/tags from the upstream Nim remote in a shallow repo.

Uses as-of-yet unmerged update to nimbus-build-system.