### PR TITLE
[build] fix nimbus-build-system

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -1,5 +1,15 @@
 import std/os
 
+const currentDir = currentSourcePath()[0 .. ^(len("config.nims") + 1)]
+
+if getEnv("NIMBUS_BUILD_SYSTEM") == "yes" and
+   # BEWARE
+   # In Nim 1.6, config files are evaluated with a working directory
+   # matching where the Nim command was invocated. This means that we
+   # must do all file existance checks with full absolute paths:
+   system.fileExists(currentDir & "nimbus-build-system.paths"):
+  include "nimbus-build-system.paths"
+
 if defined(release):
   switch("nimcache", joinPath(currentSourcePath.parentDir, "nimcache/release/$projectName"))
 else:


### PR DESCRIPTION
Ensures that we include the correct paths when building with nimbus-build-system.

Fixes Error: cannot open file: ""

Copied from:
https://github.com/status-im/nimbus-eth2/blob/1ea102b033b13847298fef4a79c802186ffcf538/config.nims#L5