### PR TITLE
[sales statemachine] add async state machine error handling

### DIFF
--- a/codex/sales.nim
+++ b/codex/sales.nim
@@ -14,6 +14,7 @@ import ./sales/salesagent
 import ./sales/availability
 import ./sales/statemachine
 import ./sales/states/downloading
+import ./sales/states/errored
 import ./sales/states/unknown
 
 ## Sales holds a list of available storage that it may sell.
@@ -135,7 +136,8 @@ proc handleRequest(sales: Sales,
     requestId,
     slotIndex,
     some availability,
-    none StorageRequest
+    none StorageRequest,
+    SaleErrored()
   )
   agent.start(SaleDownloading())
   sales.agents.add agent
@@ -160,7 +162,8 @@ proc load*(sales: Sales) {.async.} =
         request.id,
         slotIndex,
         availability,
-        some request)
+        some request,
+        SaleErrored())
       agent.start(SaleUnknown())
       sales.agents.add agent
 

--- a/codex/sales.nim
+++ b/codex/sales.nim
@@ -14,7 +14,6 @@ import ./sales/salesagent
 import ./sales/availability
 import ./sales/statemachine
 import ./sales/states/downloading
-import ./sales/states/errored
 import ./sales/states/unknown
 
 ## Sales holds a list of available storage that it may sell.
@@ -136,8 +135,7 @@ proc handleRequest(sales: Sales,
     requestId,
     slotIndex,
     some availability,
-    none StorageRequest,
-    SaleErrored()
+    none StorageRequest
   )
   agent.start(SaleDownloading())
   sales.agents.add agent
@@ -162,8 +160,7 @@ proc load*(sales: Sales) {.async.} =
         request.id,
         slotIndex,
         availability,
-        some request,
-        SaleErrored())
+        some request)
       agent.start(SaleUnknown())
       sales.agents.add agent
 

--- a/codex/sales.nim
+++ b/codex/sales.nim
@@ -96,10 +96,10 @@ func new*(_: type Sales,
     proving: proving
   ))
 
-  proc onSaleFailed(availability: Availability) =
+  proc onSaleErrored(availability: Availability) =
     sales.add(availability)
 
-  sales.context.onSaleFailed = some onSaleFailed
+  sales.context.onSaleErrored = some onSaleErrored
   sales
 
 func findAvailability*(sales: Sales, ask: StorageAsk): ?Availability =

--- a/codex/sales/salesagent.nim
+++ b/codex/sales/salesagent.nim
@@ -11,28 +11,19 @@ import ./availability
 type SalesAgent* = ref object of Machine
   context*: SalesContext
   data*: SalesData
-  errorState: SaleErrorState
 
 proc newSalesAgent*(context: SalesContext,
                     requestId: RequestId,
                     slotIndex: UInt256,
                     availability: ?Availability,
-                    request: ?StorageRequest,
-                    errorState: SaleErrorState): SalesAgent =
+                    request: ?StorageRequest): SalesAgent =
   SalesAgent(
     context: context,
     data: SalesData(
       requestId: requestId,
       availability: availability,
       slotIndex: slotIndex,
-      request: request),
-    errorState: errorState)
-
-method onError*(agent: SalesAgent, error: ref CatchableError): Event =
-  return proc (state: State): ?State =
-    let errorState = agent.errorState
-    errorState.error = error
-    SaleState(state).onError(errorState)
+      request: request))
 
 proc retrieveRequest*(agent: SalesAgent) {.async.} =
   let data = agent.data

--- a/codex/sales/salescontext.nim
+++ b/codex/sales/salescontext.nim
@@ -12,7 +12,7 @@ type
     onProve*: ?OnProve
     onClear*: ?OnClear
     onSale*: ?OnSale
-    onSaleFailed*: ?OnSaleFailed
+    onSaleErrored*: ?OnSaleErrored
     proving*: Proving
   OnStore* = proc(request: StorageRequest,
                   slot: UInt256,
@@ -25,4 +25,4 @@ type
   OnSale* = proc(availability: ?Availability, # TODO: when availability changes introduced, make availability non-optional (if we need to keep it at all)
                  request: StorageRequest,
                  slotIndex: UInt256) {.gcsafe, upraises: [].}
-  OnSaleFailed* = proc(availability: Availability) {.gcsafe, upraises: [].}
+  OnSaleErrored* = proc(availability: Availability) {.gcsafe, upraises: [].}

--- a/codex/sales/statemachine.nim
+++ b/codex/sales/statemachine.nim
@@ -14,6 +14,8 @@ export proving
 
 type
   SaleState* = ref object of State
+  SaleErrorState* = ref object of SaleState
+    error*: ref CatchableError
   SaleError* = ref object of CodexError
 
 method `$`*(state: SaleState): string {.base.} =
@@ -28,6 +30,9 @@ method onFailed*(state: SaleState, request: StorageRequest): ?State {.base, upra
 method onSlotFilled*(state: SaleState, requestId: RequestId,
                      slotIndex: UInt256): ?State {.base, upraises:[].} =
   discard
+
+method onError*(state: SaleState, errorState: SaleErrorState): ?State {.base, upraises:[].} =
+  return some State(errorState)
 
 proc cancelledEvent*(request: StorageRequest): Event =
   return proc (state: State): ?State =

--- a/codex/sales/statemachine.nim
+++ b/codex/sales/statemachine.nim
@@ -14,8 +14,6 @@ export proving
 
 type
   SaleState* = ref object of State
-  SaleErrorState* = ref object of SaleState
-    error*: ref CatchableError
   SaleError* = ref object of CodexError
 
 method `$`*(state: SaleState): string {.base.} =
@@ -30,9 +28,6 @@ method onFailed*(state: SaleState, request: StorageRequest): ?State {.base, upra
 method onSlotFilled*(state: SaleState, requestId: RequestId,
                      slotIndex: UInt256): ?State {.base, upraises:[].} =
   discard
-
-method onError*(state: SaleState, errorState: SaleErrorState): ?State {.base, upraises:[].} =
-  return some State(errorState)
 
 proc cancelledEvent*(request: StorageRequest): Event =
   return proc (state: State): ?State =

--- a/codex/sales/states/cancelled.nim
+++ b/codex/sales/states/cancelled.nim
@@ -1,8 +1,9 @@
 import ../statemachine
+import ./errorhandling
 import ./errored
 
 type
-  SaleCancelled* = ref object of SaleState
+  SaleCancelled* = ref object of ErrorHandlingState
   SaleCancelledError* = object of CatchableError
   SaleTimeoutError* = object of SaleCancelledError
 

--- a/codex/sales/states/downloading.nim
+++ b/codex/sales/states/downloading.nim
@@ -1,6 +1,7 @@
 import ../../market
 import ../salesagent
 import ../statemachine
+import ./errorhandling
 import ./cancelled
 import ./failed
 import ./filled
@@ -8,7 +9,7 @@ import ./proving
 import ./errored
 
 type
-  SaleDownloading* = ref object of SaleState
+  SaleDownloading* = ref object of ErrorHandlingState
     failedSubscription: ?market.Subscription
     hasCancelled: ?Future[void]
   SaleDownloadingError* = object of SaleError

--- a/codex/sales/states/errored.nim
+++ b/codex/sales/states/errored.nim
@@ -1,14 +1,15 @@
 import pkg/upraises
-import chronicles
+import pkg/chronicles
 import ../statemachine
 import ../salesagent
 
-type SaleErrored* = ref object of SaleErrorState
+type SaleErrored* = ref object of SaleState
+  error*: ref CatchableError
 
 method `$`*(state: SaleErrored): string = "SaleErrored"
 
-method onError*(state: SaleState, errorState: SaleErrorState): ?State {.upraises:[].} =
-  error "error during SaleErrored run", error = error.msg
+method onError*(state: SaleState, err: ref CatchableError): ?State {.upraises:[].} =
+  error "error during SaleErrored run", error = err.msg
 
 method run*(state: SaleErrored, machine: Machine): Future[?State] {.async.} =
   let agent = SalesAgent(machine)

--- a/codex/sales/states/errored.nim
+++ b/codex/sales/states/errored.nim
@@ -1,11 +1,14 @@
+import pkg/upraises
 import chronicles
 import ../statemachine
 import ../salesagent
 
-type SaleErrored* = ref object of SaleState
-  error*: ref CatchableError
+type SaleErrored* = ref object of SaleErrorState
 
 method `$`*(state: SaleErrored): string = "SaleErrored"
+
+method onError*(state: SaleState, errorState: SaleErrorState): ?State {.upraises:[].} =
+  error "error during SaleErrored run", error = error.msg
 
 method run*(state: SaleErrored, machine: Machine): Future[?State] {.async.} =
   let agent = SalesAgent(machine)

--- a/codex/sales/states/errored.nim
+++ b/codex/sales/states/errored.nim
@@ -24,9 +24,9 @@ method run*(state: SaleErrored, machine: Machine): Future[?State] {.async.} =
   # NOTE: with this in place, restoring state for a restarted node will
   # never free up availability once finished. Persisting availability
   # on disk is required for this.
-  if onSaleFailed =? context.onSaleFailed and
+  if onSaleErrored =? context.onSaleErrored and
      availability =? data.availability:
-    onSaleFailed(availability)
+    onSaleErrored(availability)
 
     await agent.unsubscribe()
 

--- a/codex/sales/states/errorhandling.nim
+++ b/codex/sales/states/errorhandling.nim
@@ -1,0 +1,9 @@
+import pkg/questionable
+import ../statemachine
+import ./errored
+
+type
+  ErrorHandlingState* = ref object of SaleState
+
+method onError*(state: ErrorHandlingState, error: ref CatchableError): ?State =
+  some State(SaleErrored(error: error))

--- a/codex/sales/states/failed.nim
+++ b/codex/sales/states/failed.nim
@@ -1,8 +1,9 @@
-import ./errored
 import ../statemachine
+import ./errorhandling
+import ./errored
 
 type
-  SaleFailed* = ref object of SaleState
+  SaleFailed* = ref object of ErrorHandlingState
   SaleFailedError* = object of SaleError
 
 method `$`*(state: SaleFailed): string = "SaleFailed"

--- a/codex/sales/states/filled.nim
+++ b/codex/sales/states/filled.nim
@@ -1,13 +1,14 @@
 import pkg/questionable
+import ../statemachine
+import ../salesagent
+import ./errorhandling
 import ./errored
 import ./finished
 import ./cancelled
 import ./failed
-import ../statemachine
-import ../salesagent
 
 type
-  SaleFilled* = ref object of SaleState
+  SaleFilled* = ref object of ErrorHandlingState
   SaleFilledError* = object of CatchableError
   HostMismatchError* = object of SaleFilledError
 

--- a/codex/sales/states/filling.nim
+++ b/codex/sales/states/filling.nim
@@ -1,13 +1,14 @@
 import ../../market
 import ../statemachine
 import ../salesagent
+import ./errorhandling
 import ./filled
 import ./errored
 import ./cancelled
 import ./failed
 
 type
-  SaleFilling* = ref object of SaleState
+  SaleFilling* = ref object of ErrorHandlingState
     proof*: seq[byte]
   SaleFillingError* = object of CatchableError
 

--- a/codex/sales/states/filling.nim
+++ b/codex/sales/states/filling.nim
@@ -10,7 +10,6 @@ import ./failed
 type
   SaleFilling* = ref object of ErrorHandlingState
     proof*: seq[byte]
-  SaleFillingError* = object of CatchableError
 
 method `$`*(state: SaleFilling): string = "SaleFilling"
 
@@ -28,12 +27,4 @@ method run(state: SaleFilling, machine: Machine): Future[?State] {.async.} =
   let data = SalesAgent(machine).data
   let market = SalesAgent(machine).context.market
 
-  try:
-    await market.fillSlot(data.requestId, data.slotIndex, state.proof)
-
-  except CancelledError:
-    raise
-
-  except CatchableError as e:
-    let error = newException(SaleFillingError, "unknown sale filling error", e)
-    return some State(SaleErrored(error: error))
+  await market.fillSlot(data.requestId, data.slotIndex, state.proof)

--- a/codex/sales/states/finished.nim
+++ b/codex/sales/states/finished.nim
@@ -1,12 +1,13 @@
 import pkg/chronos
 import ../statemachine
 import ../salesagent
+import ./errorhandling
 import ./cancelled
 import ./errored
 import ./failed
 
 type
-  SaleFinished* = ref object of SaleState
+  SaleFinished* = ref object of ErrorHandlingState
   SaleFinishedError* = object of CatchableError
 
 method `$`*(state: SaleFinished): string = "SaleFinished"

--- a/codex/sales/states/proving.nim
+++ b/codex/sales/states/proving.nim
@@ -1,5 +1,6 @@
 import ../statemachine
 import ../salesagent
+import ./errorhandling
 import ./filling
 import ./cancelled
 import ./failed
@@ -7,7 +8,7 @@ import ./filled
 import ./errored
 
 type
-  SaleProving* = ref object of SaleState
+  SaleProving* = ref object of ErrorHandlingState
   SaleProvingError* = object of CatchableError
 
 method `$`*(state: SaleProving): string = "SaleProving"

--- a/codex/sales/states/proving.nim
+++ b/codex/sales/states/proving.nim
@@ -5,11 +5,9 @@ import ./filling
 import ./cancelled
 import ./failed
 import ./filled
-import ./errored
 
 type
   SaleProving* = ref object of ErrorHandlingState
-  SaleProvingError* = object of CatchableError
 
 method `$`*(state: SaleProving): string = "SaleProving"
 
@@ -27,19 +25,11 @@ method run*(state: SaleProving, machine: Machine): Future[?State] {.async.} =
   let data = SalesAgent(machine).data
   let context = SalesAgent(machine).context
 
-  try:
-    without request =? data.request:
-      raiseAssert "no sale request"
+  without request =? data.request:
+    raiseAssert "no sale request"
 
-    without onProve =? context.onProve:
-      raiseAssert "onProve callback not set"
+  without onProve =? context.onProve:
+    raiseAssert "onProve callback not set"
 
-    let proof = await onProve(request, data.slotIndex)
-    return some State(SaleFilling(proof: proof))
-
-  except CancelledError:
-    raise
-
-  except CatchableError as e:
-    let error = newException(SaleProvingError, "unknown sale proving error", e)
-    return some State(SaleErrored(error: error))
+  let proof = await onProve(request, data.slotIndex)
+  return some State(SaleFilling(proof: proof))

--- a/codex/utils/asyncstatemachine.nim
+++ b/codex/utils/asyncstatemachine.nim
@@ -46,10 +46,7 @@ proc scheduler(machine: Machine) {.async.} =
   proc onRunComplete(udata: pointer) {.gcsafe.} =
     var fut = cast[FutureBase](udata)
     if fut.failed():
-      try:
-        machine.schedule(machine.onError(fut.error))
-      except AsyncQueueFullError as e:
-        error "Cannot set transition value because queue is full", error = e.msg
+      machine.schedule(machine.onError(fut.error))
 
   try:
     while true:

--- a/codex/utils/asyncstatemachine.nim
+++ b/codex/utils/asyncstatemachine.nim
@@ -28,8 +28,12 @@ proc schedule*(machine: Machine, event: Event) =
 method run*(state: State, machine: Machine): Future[?State] {.base, async.} =
   discard
 
-method onError*(machine: Machine, error: ref CatchableError): Event {.base.} =
-  raiseAssert "not implemented"
+method onError*(state: State, error: ref CatchableError): ?State {.base.} =
+  raise (ref Defect)(msg: "error in state machine: " & error.msg, parent: error)
+
+proc onError(machine: Machine, error: ref CatchableError): Event =
+  return proc (state: State): ?State =
+    state.onError(error)
 
 proc run(machine: Machine, state: State) {.async.} =
   try:

--- a/tests/codex/helpers/mockmarket.nim
+++ b/tests/codex/helpers/mockmarket.nim
@@ -115,7 +115,11 @@ method requestState*(market: MockMarket,
 
 method slotState*(market: MockMarket,
                   slotId: SlotId): Future[SlotState] {.async.} =
-  return market.slotState[slotId]
+  if market.slotState.hasKey(slotId):
+    return market.slotState[slotId]
+  else:
+    return SlotState.Free
+
 
 method getRequestEnd*(market: MockMarket,
                       id: RequestId): Future[SecondsSince1970] {.async.} =

--- a/tests/codex/utils/testasyncstatemachine.nim
+++ b/tests/codex/utils/testasyncstatemachine.nim
@@ -9,8 +9,9 @@ type
   State1 = ref object of State
   State2 = ref object of State
   State3 = ref object of State
+  State4 = ref object of State
 
-var runs, cancellations = [0, 0, 0]
+var runs, cancellations, errors = [0, 0, 0, 0]
 
 method onMoveToNextStateEvent*(state: State): ?State {.base, upraises:[].} =
   discard
@@ -36,111 +37,59 @@ method run(state: State3, machine: Machine): Future[?State] {.async.} =
 method onMoveToNextStateEvent(state: State3): ?State =
   some State(State1.new())
 
+method run(state: State4, machine: Machine): Future[?State] {.async.} =
+  inc runs[3]
+  raise newException(ValueError, "failed")
+
+method onError(state: State4, error: ref CatchableError): ?State =
+  inc errors[3]
+  some State(State2.new())
+
 suite "async state machines":
   var machine: Machine
-  var state1, state2: State
 
   proc moveToNextStateEvent(state: State): ?State =
     state.onMoveToNextStateEvent()
 
   setup:
-    runs = [0, 0, 0]
-    cancellations = [0, 0, 0]
+    runs = [0, 0, 0, 0]
+    cancellations = [0, 0, 0, 0]
+    errors = [0, 0, 0, 0]
     machine = Machine.new()
-    state1 = State1.new()
-    state2 = State2.new()
 
   test "should call run on start state":
-    machine.start(state1)
+    machine.start(State1.new())
     check eventually runs[0] == 1
 
   test "moves to next state when run completes":
-    machine.start(state1)
-    check eventually runs == [1, 1, 0]
+    machine.start(State1.new())
+    check eventually runs == [1, 1, 0, 0]
 
   test "state2 moves to state3 on event":
-    machine.start(state2)
+    machine.start(State2.new())
     machine.schedule(moveToNextStateEvent)
-    check eventually runs == [0, 1, 1]
+    check eventually runs == [0, 1, 1, 0]
 
   test "state transition will cancel the running state":
-    machine.start(state2)
+    machine.start(State2.new())
     machine.schedule(moveToNextStateEvent)
-    check eventually cancellations == [0, 1, 0]
+    check eventually cancellations == [0, 1, 0, 0]
 
   test "scheduled events are handled one after the other":
-    machine.start(state2)
+    machine.start(State2.new())
     machine.schedule(moveToNextStateEvent)
     machine.schedule(moveToNextStateEvent)
-    check eventually runs == [1, 2, 1]
+    check eventually runs == [1, 2, 1, 0]
 
   test "stops scheduling and current state":
-    machine.start(state2)
+    machine.start(State2.new())
     await sleepAsync(1.millis)
     machine.stop()
     machine.schedule(moveToNextStateEvent)
     await sleepAsync(1.millis)
-    check runs == [0, 1, 0]
-    check cancellations == [0, 1, 0]
+    check runs == [0, 1, 0, 0]
+    check cancellations == [0, 1, 0, 0]
 
-type
-  MyMachine = ref object of Machine
-  State4 = ref object of State
-  State5 = ref object of State
-  ErrorState = ref object of State
-    error: ref CatchableError
-  MyMachineError = object of CatchableError
-
-var errorRuns = 0
-var onErrorCalled, onErrorOverridden = false
-
-proc raiseMyMachineError() =
-  raise newException(MyMachineError, "some error")
-
-method run*(state: State4, machine: Machine): Future[?State] {.async.} =
-  raiseMyMachineError()
-
-method run*(state: State5, machine: Machine): Future[?State] {.async.} =
-  raiseMyMachineError()
-
-method run(state: ErrorState, machine: Machine): Future[?State] {.async.} =
-  check not state.error.isNil
-  check state.error of MyMachineError
-  check state.error.msg == "some error"
-  inc errorRuns
-
-method onError*(state: State, error: ref CatchableError): ?State {.base, upraises:[].} =
-  return some State(ErrorState(error: error))
-
-method onError*(state: State5, error: ref CatchableError): ?State {.upraises:[].} =
-  onErrorOverridden = true
-
-method onError*(machine: MyMachine, error: ref CatchableError): Event =
-  onErrorCalled = true
-  return proc (state: State): ?State =
-    state.onError(error)
-
-suite "async state machines - errors":
-  var machine: MyMachine
-  var state4, state5: State
-
-  setup:
-    errorRuns = 0
-    machine = MyMachine.new()
-    state4 = State4.new()
-    state5 = State5.new()
-    onErrorCalled = false
-    onErrorOverridden = false
-
-  test "catches errors in run":
-    machine.start(state4)
-    check eventually onErrorCalled
-
-  test "errors in run can be handled at the base state level":
-    machine.start(state4)
-    check eventually errorRuns == 1
-
-  test "errors in run can be handled by overridden onError at the state level":
-    machine.start(state5)
-    check eventually onErrorOverridden
-
+  test "forwards errors to error handler":
+    machine.start(State4.new())
+    check eventually errors == [0, 0, 0, 1] and runs == [0, 1, 0, 1]


### PR DESCRIPTION
- add error handling to catch errors during `state.run`
- Sales: create `ErrorHandlingState` to use a base class for handling the `onError` callback, which is called when there is an error in the state's run method.
- Sales: `onError` can be overridden by individual states if needed.
- Because there is already a state named SaleFailed which is meant to react to an onchain `RequestFailed` event and also because this callback is called from `SaleErrored`, renaming to `onSaleErrored` prevents ambiguity and confusion as to what has happened at the callback callsite.
### NOTE
- base branch is #306 