### PR TITLE
[build] fix: ignore logging when running singular tests

### DIFF
--- a/tests/config.nims
+++ b/tests/config.nims
@@ -1,0 +1,8 @@
+--path:".."
+--threads:on
+--tlsEmulation:off
+
+when not defined(chronicles_log_level):
+  --define:"chronicles_log_level:NONE" # compile all log statements
+  --define:"chronicles_sinks:textlines[dynamic]" # allow logs to be filtered at runtime
+  --"import":"logging" # ensure that logging is ignored at runtime

--- a/tests/logging.nim
+++ b/tests/logging.nim
@@ -4,3 +4,6 @@ proc ignoreLogging(level: LogLevel, message: LogOutputStr) =
   discard
 
 defaultChroniclesStream.output.writer = ignoreLogging
+
+{.warning[UnusedImport]:off.}
+{.used.}

--- a/tests/nim.cfg
+++ b/tests/nim.cfg
@@ -1,7 +1,0 @@
---path:".."
---threads:on
---tlsEmulation:off
-
--d:chronicles_log_level:"NONE" # compile all log statements
--d:chronicles_sinks:"textlines[dynamic]" # allow logs to be filtered at runtime
---import:logging # ensure that logging is ignored at runtime

--- a/tests/nim.cfg
+++ b/tests/nim.cfg
@@ -3,4 +3,5 @@
 --tlsEmulation:off
 
 -d:chronicles_log_level:"NONE" # compile all log statements
--d:chronicles_sinks:"textlines[dynamic]" # allow logs to be filtered by tests
+-d:chronicles_sinks:"textlines[dynamic]" # allow logs to be filtered at runtime
+--import:logging # ensure that logging is ignored at runtime

--- a/tests/testCodex.nim
+++ b/tests/testCodex.nim
@@ -1,4 +1,3 @@
-import ./logging
 import ./codex/teststores
 import ./codex/testblockexchange
 import ./codex/teststorageproofs

--- a/tests/testContracts.nim
+++ b/tests/testContracts.nim
@@ -1,4 +1,3 @@
-import ./logging
 import ./contracts/testCollateral
 import ./contracts/testContracts
 import ./contracts/testMarket

--- a/tests/testIntegration.nim
+++ b/tests/testIntegration.nim
@@ -1,4 +1,3 @@
-import ./logging
 import ./integration/testIntegration
 import ./integration/testblockexpiration
 


### PR DESCRIPTION
Ensures that logging is ignored at runtime when running individual tests using `nim c -r tests/...`