### PR TITLE
fix: repostore started flag in stop()

### DIFF
--- a/codex/stores/repostore.nim
+++ b/codex/stores/repostore.nim
@@ -371,14 +371,15 @@ proc start*(self: RepoStore): Future[void] {.async.} =
 proc stop*(self: RepoStore): Future[void] {.async.} =
   ## Stop repo
   ##
-
-  if self.started:
+  if not self.started:
     trace "Repo is not started"
     return
 
   trace "Stopping repo"
   (await self.repoDs.close()).expect("Should close repo store!")
   (await self.metaDs.close()).expect("Should close meta store!")
+
+  self.started = false
 
 func new*(
   T: type RepoStore,

--- a/tests/codex/stores/testrepostore.nim
+++ b/tests/codex/stores/testrepostore.nim
@@ -22,6 +22,39 @@ import ../helpers
 import ../helpers/mockclock
 import ./commonstoretests
 
+suite "Test RepoStore start/stop":
+
+  var
+    repoDs: Datastore
+    metaDs: Datastore
+
+  setup:
+    repoDs = SQLiteDatastore.new(Memory).tryGet()
+    metaDs = SQLiteDatastore.new(Memory).tryGet()
+
+  test "Should set started flag once started":
+    let repo = RepoStore.new(repoDs, metaDs, quotaMaxBytes = 200)
+    await repo.start()
+    check repo.started
+
+  test "Should set started flag to false once stopped":
+    let repo = RepoStore.new(repoDs, metaDs, quotaMaxBytes = 200)
+    await repo.start()
+    await repo.stop()
+    check not repo.started
+
+  test "Should allow start to be called multiple times":
+    let repo = RepoStore.new(repoDs, metaDs, quotaMaxBytes = 200)
+    await repo.start()
+    await repo.start()
+    check repo.started
+
+  test "Should allow stop to be called multiple times":
+    let repo = RepoStore.new(repoDs, metaDs, quotaMaxBytes = 200)
+    await repo.stop()
+    await repo.stop()
+    check not repo.started
+
 suite "RepoStore":
   var
     repoDs: Datastore
@@ -47,6 +80,29 @@ suite "RepoStore":
 
   proc createTestBlock(size: int): bt.Block =
     bt.Block.new('a'.repeat(size).toBytes).tryGet()
+
+  test "Should set started flag once started":
+    let repo = RepoStore.new(repoDs, metaDs, quotaMaxBytes = 200)
+    await repo.start()
+    check repo.started
+
+  test "Should set started flag to false once stopped":
+    let repo = RepoStore.new(repoDs, metaDs, quotaMaxBytes = 200)
+    await repo.start()
+    await repo.stop()
+    check not repo.started
+
+  test "Should allow start to be called multiple times":
+    let repo = RepoStore.new(repoDs, metaDs, quotaMaxBytes = 200)
+    await repo.start()
+    await repo.start()
+    check repo.started
+
+  test "Should allow stop to be called multiple times":
+    let repo = RepoStore.new(repoDs, metaDs, quotaMaxBytes = 200)
+    await repo.stop()
+    await repo.stop()
+    check not repo.started
 
   test "Should update current used bytes on block put":
     let blk = createTestBlock(200)


### PR DESCRIPTION
- in stop, check not self.started, and set flag at the end
- add tests