### PR TITLE
ci: lint openapi on all prs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,12 +7,12 @@ on:
     paths:
       - 'openapi.yaml'
       - '.github/workflows/docs.yml'
-#  pull_request:
-#    branches:
-#      - '**'
-#    paths:
-#      - 'openapi.yaml'
-#      - '.github/workflows/docs.yml'
+  pull_request:
+    branches:
+      - '**'
+    paths:
+      - 'openapi.yaml'
+      - '.github/workflows/docs.yml'
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -21,8 +21,8 @@ permissions:
   id-token: write
 
 jobs:
-  build:
-    name: Preview
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -37,6 +37,20 @@ jobs:
       - name: Lint OpenAPI
         shell: bash
         run: npx @redocly/cli lint openapi.yaml
+
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
 
       - name: Build OpenAPI
         shell: bash


### PR DESCRIPTION
This PR enables the linting of OpenAPI on all PRs, while keeping the deployment only for the `main` branches