### PR TITLE
Update references to `make exec`

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -129,10 +129,10 @@ $ make V=1 update
 
 In Bash run
 ```text
-$ make exec
+$ make
 ```
 
-The `exec` target creates the `build/codex` executable.
+The default `make` target creates the `build/codex` executable.
 
 ## Example usage
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For detailed instructions on preparing to build nim-codex see [*Building Codex*]
 To build the project, clone it and run:
 
 ```bash
-make update && make exec
+make update && make
 ```
 
 The executable will be placed under the `build` directory under the project root.


### PR DESCRIPTION
In #356 `make exec` was replaced with the default `make` call, but the docs still refer to `make exec`.