### PR TITLE
Fix CI?

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,7 @@ jobs:
             export PATH="${PATH}:/c/program files/nodejs"
           fi
           npm install
-          npm start &
-          sleep 120 # allow for some time before the contracts are deployed
+          nohup npm start&
 
       - name: Contract tests
         run: make -j${ncpu} testContracts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           fi
           npm install
           npm start &
-          sleep 10 # allow for some time before the contracts are deployed
+          sleep 120 # allow for some time before the contracts are deployed
 
       - name: Contract tests
         run: make -j${ncpu} testContracts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
           fi
           npm install
           npm start &
+          sleep 10 # allow for some time before the contracts are deployed
 
       - name: Contract tests
         run: make -j${ncpu} testContracts


### PR DESCRIPTION
CI is failing on contract tests. This seems to be caused by a crash or hang of hardhat. We're starting hardhat in the background by invoking `npm start&`, which always worked. Recent changes include minting of tokens when deploying hardhat (https://github.com/status-im/codex-contracts-eth/pull/52), which takes a while, so maybe that is causing it?

Attempts to fix:
- ~~Allow for some more time, for Hardhat to start and contracts to be deployed.~~
- ~~Try using nohup~~