### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,12 @@ jobs:
       - name: Unit tests
         run: make -j${ncpu} test
 
+      # workaround for https://github.com/NomicFoundation/hardhat/issues/3877
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+         node-version: 18.15
+
       - name: Start Ethereum node with Codex contracts
         working-directory: vendor/codex-contracts-eth
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,10 +55,9 @@ jobs:
 
       - name: Start Ethereum node with Codex contracts
         working-directory: vendor/codex-contracts-eth
+        env:
+          MSYS2_PATH_TYPE: inherit
         run: |
-          if [[ '${{ matrix.os }}' == 'windows' ]]; then
-            export PATH="${PATH}:/c/program files/nodejs"
-          fi
           npm install
           npm start &
 


### PR DESCRIPTION
Workaround for crash in Hardhat with the latest Node.js. See also: https://github.com/NomicFoundation/hardhat/issues/3877

Closes #403, #407